### PR TITLE
NIAD-1838: When a document placeholder is generated because there is no content type/MIME mapping nothing is logged

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DocumentReferenceToNarrativeStatementMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DocumentReferenceToNarrativeStatementMapper.java
@@ -59,8 +59,8 @@ public class DocumentReferenceToNarrativeStatementMapper {
         final Attachment attachment = DocumentReferenceUtils.extractAttachment(documentReference);
         final String attachmentContentType = DocumentReferenceUtils.extractContentType(attachment);
 
-        boolean isContentTypeSupported;
-        if (!(isContentTypeSupported = supportedContentTypes.isContentTypeSupported(attachmentContentType))) {
+        boolean isContentTypeSupported = supportedContentTypes.isContentTypeSupported(attachmentContentType);
+        if (!isContentTypeSupported) {
             LOGGER.info("Unsupported ContentType '{}'!", attachmentContentType);
         }
 


### PR DESCRIPTION
Ticket -> [NIAD-1838](https://gpitbjss.atlassian.net/browse/NIAD-1838)