### PR TITLE
Improve the API documentation

### DIFF
--- a/OPERATING.md
+++ b/OPERATING.md
@@ -13,7 +13,7 @@ Variables without a default value and not marked optional, *MUST* be defined for
 
 | Environment Variable     | Default                   | Description                                                                               |
 |--------------------------|---------------------------|-------------------------------------------------------------------------------------------|
-| GP2GP_SERVER_PORT        | 8080                      | The port on which the GP2GP Adapter will run.                                             |
+| GP2GP_SERVER_PORT        | 8080                      | The port on which the GP2GP Adapter API will run.                                         |
 | GP2GP_ROOT_LOGGING_LEVEL | WARN                      | The logging level applied to the entire application (including third-party dependencies). |
 | GP2GP_LOGGING_LEVEL      | INFO                      | The logging level applied to GP2GP adaptor components.                                    |
 | GP2GP_LOGGING_FORMAT     | (*)                       | Defines how to format log events on stdout                                                |

--- a/README.md
+++ b/README.md
@@ -18,16 +18,21 @@ GP2GP 2.2b producer, or those wishing to decommission their existing producer, m
 
 1. [Guidance for setting up the GP2GP adaptors in INT](https://github.com/NHSDigital/nia-patient-switching-standard-adaptor/blob/main/getting-started-instructions.md)
 1. [Guidance for operating the adaptor as a New Market Entrant](OPERATING.md)
-1. [Guidance on integrating with the adaptors APIs](#how-to-query-the-ehr-status-api)
+1. [Guidance on integrating with the adaptors APIs](#adaptor-api)
 1. [Documentation on how this adaptor maps GPConnect concepts to GP2GP concepts](https://github.com/NHSDigital/patient-switching-adaptors-mapping-documentation)
 
-## How to query the EHR Status API and the Requests endpoint
+## Adaptor API
 
-An API is provided to query the status of any transfer to an incumbent.
+An API is provided to query the status of GP2GP transfers that have been processed, and initiate a resend of an
+Electronic Health Record which has failed to transfer.
 
-The API has been documented using the OpenAPI Specification (version 3.0.1). The documentation includes detailed descriptions of endpoints,
-parameters, and data models, as well as examples of requests and responses to help developers integrate and use the API effectively
-[Ehr Extract OpenAPI Documentation](gp2gp_adaptor_response_docs.yaml)
+The API has been [documented using the OpenAPI Specification (version 3.0.1)](gp2gp_adaptor_response_docs.yaml) and
+includes detailed descriptions of endpoints, parameters, and data models, as well as examples of requests and responses
+to help developers integrate and use the API effectively.
+
+The documentation can also be displayed using [editor.swagger.io (exteral link)][swagger_editor].
+
+[swagger_editor]: https://editor.swagger.io/?url=https://raw.githubusercontent.com/NHSDigital/integration-adaptor-gp2gp-sending/refs/heads/main/gp2gp_adaptor_response_docs.yaml
 
 ## Diagrams
 


### PR DESCRIPTION
## What

Clarify that GP2GP_SERVER_PORT is for the API specifically.

Fix broken link in the "Table of contents" to the API information.

Link out to the editor.swagger.io interface which is a bit nicer for viewing the spec.

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
