### PR TITLE
Prevent Sonar Reports and Mutation Testing running when triggered by Dependabot

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -107,16 +107,15 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Execute Unit Tests
-        if: github.actor != 'dependabot[bot]'
-        run: ./gradlew test jacocoTestReport sonar --parallel --build-cache
+        run: |
+          if [[ $GITHUB_ACTOR == 'dependabot[bot]' ]]; then
+            ./gradlew test jacocoTestReport --parallel --build-cache
+          else
+            ./gradlew test jacocoTestReport sonar --parallel --build-cache
+          fi
         working-directory: ./service
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
-      - name: Execute Unit Tests
-        if: github.actor == 'dependabot[bot]'
-        run: ./gradlew test jacocoTestReport --parallel --build-cache
-        working-directory: ./service
 
       - name: Collect Artifacts
         if: always()

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -107,10 +107,16 @@ jobs:
         uses: gradle/actions/setup-gradle@v4
 
       - name: Execute Unit Tests
+        if: github.actor != 'dependabot[bot]'
         run: ./gradlew test jacocoTestReport sonar --parallel --build-cache
         working-directory: ./service
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Execute Unit Tests
+        if: github.actor == 'dependabot[bot]'
+        run: ./gradlew test jacocoTestReport --parallel --build-cache
+        working-directory: ./service
 
       - name: Collect Artifacts
         if: always()

--- a/.github/workflows/mutationtesting.yml
+++ b/.github/workflows/mutationtesting.yml
@@ -6,7 +6,7 @@ jobs:
   pitest:
     # Only run on PRs from the repo. PRs from forks will fail due to lack of permissions and
     # must use a two stage process
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project


### PR DESCRIPTION
## What

* Add an if condition to the mutation testing GitHub action to prevent the mutation testing from being run if the GitHub actor is dependabot.
* Add a conditional job for the build workflow to not generate a sonar report when triggered by dependabot.


## Why

Currently the mutation testing workflow triggers when dependabot raises a PR, and generating the Sonar report also fails in the unit tests stage of the build action.
These fail as Dependabot does not have access to GitHub secrets.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
