### PR TITLE
Delay the LargePatientRecord response by 5 minutes

### DIFF
--- a/wiremock/README.md
+++ b/wiremock/README.md
@@ -87,7 +87,8 @@ To change the patient record returned to be [PWTP3, which has many Prescriptions
 curl --request PUT --data '{"state": "Medications"}' http://localhost:8110/__admin/scenarios/migrateStructuredRecord/state
 ```
 
-To change the patient record returned to be [Large Patient Record](stubs/__files/correctPatientStructuredRecordLargePayload.json):
+To change the patient record returned to be [Large Patient Record](stubs/__files/correctPatientStructuredRecordLargePayload.json)
+and also delay the response being sent back by 5 minutes.
 
 ```shell
 curl --request PUT --data '{"state": "Large Patient Record"}' http://localhost:8110/__admin/scenarios/migrateStructuredRecord/state

--- a/wiremock/stubs/mappings/migrateStructuredRecord Large Patient Record.json
+++ b/wiremock/stubs/mappings/migrateStructuredRecord Large Patient Record.json
@@ -8,6 +8,7 @@
   },
   "response": {
     "status": 200,
+    "fixedDelayMilliseconds": 300000,
     "bodyFileName": "correctPatientStructuredRecordLargePayload.json",
     "headers": {
       "Server": "nginx",


### PR DESCRIPTION
## Why

E2E testing of slow GP Connect responses

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
