### PR TITLE
Generate a unique ID for the skeleton ehrComposition element

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapper.java
@@ -69,6 +69,7 @@ public class EhrExtractMapper {
 
     public String buildEhrCompositionForSkeletonEhrExtract(String documentIdOfCompressedEhrExtract) {
         var skeletonComponentTemplateParameters = SkeletonComponentTemplateParameters.builder()
+            .ehrCompositionId(randomIdGeneratorService.createNewId())
             .narrativeStatementId(documentIdOfCompressedEhrExtract)
             .availabilityTime(DateFormatUtil.toHl7Format(timestampService.now()))
             .build();

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/SkeletonComponentTemplateParameters.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/SkeletonComponentTemplateParameters.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 @Setter
 @Builder
 public class SkeletonComponentTemplateParameters {
+    private String ehrCompositionId;
     private String narrativeStatementId;
     private String availabilityTime;
     private String effectiveTime;

--- a/service/src/main/resources/templates/ehr_skeleton_component_template.mustache
+++ b/service/src/main/resources/templates/ehr_skeleton_component_template.mustache
@@ -1,6 +1,6 @@
 <component typeCode="COMP">
     <ehrComposition classCode="COMPOSITION" moodCode="EVN">
-        <id root="{{narrativeStatementId}}" />
+        <id root="{{ehrCompositionId}}" />
         <code nullFlavor="UNK"/>
         <statusCode code="COMPLETE" />
         <effectiveTime nullFlavor="UNK"/>

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperTest.java
@@ -83,12 +83,13 @@ public class EhrExtractMapperTest {
     public void When_BuildEhrCompositionForSkeletonEhrExtract_Expect_ExpectedComponentBuilt() {
         var documentId = "documentId";
 
+        when(randomIdGeneratorService.createNewId()).thenReturn("ehrCompositionId");
         when(timestampService.now()).thenReturn(Instant.parse("2024-01-01T01:01:01.000Z"));
 
         var expected = """
                 <component typeCode="COMP">
                     <ehrComposition classCode="COMPOSITION" moodCode="EVN">
-                        <id root="documentId" />
+                        <id root="ehrCompositionId" />
                         <code nullFlavor="UNK"/>
                         <statusCode code="COMPLETE" />
                         <effectiveTime nullFlavor="UNK"/>


### PR DESCRIPTION
## Why

By sending out a message where both the ehrComposition and NarrativeStatement both share the same `narrativeStatementId` value it was causing the requesting adaptor problems when ingesting the GP2GP message.

By generating a random value we should avoid this defect.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
