### PR TITLE
XML Escape text fields when mapping to `MedicationStatement`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * When mapping a `DiagnosticReport` which contains at least one `Specimen`,
   any specimens which didn't belong to a test result were previously not sent to the requesting system.
   Now, a fake `Observation` is created in which any `Observation`-less `Specimen`s are placed.
+* When mapping a `MedicationRequest` to a `MedicationStatement`, user provided text fields are now correctly escaped in 
+  the produced XML.
 
 ## [2.2.1] - 2024-12-10
 

--- a/service/src/main/resources/templates/ehr_medication_statement_authorise_template.mustache
+++ b/service/src/main/resources/templates/ehr_medication_statement_authorise_template.mustache
@@ -61,7 +61,7 @@
                 </reversalOf>
                 <pertinentInformation typeCode="PERT">
                     <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN"{{^ehrSupplyDiscontinueReasonText}} nullFlavor="UNK"{{/ehrSupplyDiscontinueReasonText}}>
-                        {{#ehrSupplyDiscontinueReasonText}}<text>{{{ehrSupplyDiscontinueReasonText}}}</text>{{/ehrSupplyDiscontinueReasonText}}{{^ehrSupplyDiscontinueReasonText}}<text>Stopped</text>{{/ehrSupplyDiscontinueReasonText}}
+                        {{#ehrSupplyDiscontinueReasonText}}<text>{{ehrSupplyDiscontinueReasonText}}</text>{{/ehrSupplyDiscontinueReasonText}}{{^ehrSupplyDiscontinueReasonText}}<text>Stopped</text>{{/ehrSupplyDiscontinueReasonText}}
                     </pertinentSupplyAnnotation>
                 </pertinentInformation>
             </ehrSupplyDiscontinue>

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapperTest.java
@@ -160,6 +160,10 @@ public class MedicationStatementMapperTest {
         + "medication-request-empty-prescribing-agency-coding-array.json";
     private static final String INPUT_JSON_WITH_PRESCRIBING_AGENCY_ERROR_MISSING_CODEABLE_CONCEPT = TEST_FILE_DIRECTORY
         + "medication-request-missing-prescribing-agency-codeable-concept.json";
+    private static final String INPUT_JSON_WITH_SPECIAL_CHARACTERS_IN_TEXT_FIELDS = TEST_FILE_DIRECTORY
+        + "medication-request-special-character-in-code.json";
+    private static final String OUTPUT_XML_WITH_ESCAPED_XML_TEXT_VALUES = TEST_FILE_DIRECTORY
+        + "medication-statement-with-xml-escaped-text-values.xml";
     private static final String CONFIDENTIALITY_CODE = """
         <confidentialityCode
             code="NOPAT"
@@ -234,7 +238,8 @@ public class MedicationStatementMapperTest {
             Arguments.of(INPUT_JSON_WITH_PLAN_NO_INFO_PRESCRIPTION_TEXT, OUTPUT_XML_WITH_AUTHORISE_REPEAT_PRESCRIPTION),
             Arguments.of(INPUT_JSON_WITH_EXTENSION_STATUS_REASON_TEXT, OUTPUT_XML_WITH_STATUS_REASON_TEXT),
             Arguments.of(INPUT_JSON_WITH_NO_RECORDER_REFERENCE, OUTPUT_XML_WITH_NO_PARTICIPANT),
-            Arguments.of(INPUT_JSON_WITH_INVALID_RECORDER_REFERENCE_TYPE, OUTPUT_XML_WITH_NO_PARTICIPANT)
+            Arguments.of(INPUT_JSON_WITH_INVALID_RECORDER_REFERENCE_TYPE, OUTPUT_XML_WITH_NO_PARTICIPANT),
+            Arguments.of(INPUT_JSON_WITH_SPECIAL_CHARACTERS_IN_TEXT_FIELDS, OUTPUT_XML_WITH_ESCAPED_XML_TEXT_VALUES)
         );
     }
 
@@ -278,7 +283,7 @@ public class MedicationStatementMapperTest {
 
     @ParameterizedTest
     @MethodSource("resourceFileExpectException")
-    public void When_MappingMedicationRequestWithInvalidResource_Expect_Exception(String inputJson) throws IOException {
+    public void When_MappingMedicationRequestWithInvalidResource_Expect_Exception(String inputJson) {
         var jsonInput = ResourceTestFileUtils.getFileContent(inputJson);
         MedicationRequest parsedMedicationRequest = new FhirParseService().parseResource(jsonInput, MedicationRequest.class);
 
@@ -302,7 +307,7 @@ public class MedicationStatementMapperTest {
     }
 
     @Test
-    public void When_MappingMedicationRequestWithRequesterWithOnBehalfOf_Expect_ParticipantMappedToAgent() throws IOException {
+    public void When_MappingMedicationRequestWithRequesterWithOnBehalfOf_Expect_ParticipantMappedToAgent() {
         when(mockRandomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
         codeableConceptCdMapper = new CodeableConceptCdMapper();
         var bundleInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_BUNDLE);
@@ -350,7 +355,7 @@ public class MedicationStatementMapperTest {
     @ParameterizedTest
     @MethodSource("resourceFilesWithParticipant")
     public void When_MappingMedicationRequestWithParticipant_Expect_ParticipantMappedToAgent(
-        String inputJson, String agentId) throws IOException {
+        String inputJson, String agentId) {
         when(mockRandomIdGeneratorService.createNewId()).thenReturn(TEST_ID);
         codeableConceptCdMapper = new CodeableConceptCdMapper();
         var bundleInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_BUNDLE);
@@ -397,7 +402,7 @@ public class MedicationStatementMapperTest {
     @ParameterizedTest
     @MethodSource("resourceFilesWithMedicationStatement")
     public void When_MappingMedicationRequest_WithMedicationStatement_Expect_PrescribingAgencyMappedToSupplyType(
-        String inputJson, String outputXml) throws IOException {
+        String inputJson, String outputXml) {
 
         var expected = ResourceTestFileUtils.getFileContent(outputXml);
 

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-request-special-character-in-code.json
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-request-special-character-in-code.json
@@ -1,0 +1,64 @@
+{
+    "resourceType":"MedicationRequest",
+    "id":"3377543D-5B1B-4C4F-BFF6-9F7BC3A1C3B8",
+    "meta":{
+        "profile":[
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+        ]
+    },
+    "extension":[
+        {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationStatusReason-1",
+            "extension": [
+                {
+                    "url": "statusReason",
+                    "valueCodeableConcept": {
+                        "text": "<<Test Code Text>>"
+                    }
+                },
+                {
+                    "url": "statusChangeDate",
+                    "valueDateTime": "2010-01-18T14:33:16.397+00:00"
+                }
+            ]
+        },
+        {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+            "valueCodeableConcept": {
+                "coding": [
+                    {
+                        "system": "https://fhir.nhs.uk/STU3/CodeSystem/CareConnect-PrescriptionType-1",
+                        "code": "acute",
+                        "display": "Acute"
+                    }
+                ]
+            }
+        }
+    ],
+    "authoredOn": "2021-01-01T00:00:00+00:00",
+    "status": "stopped",
+    "intent": "plan",
+    "dispenseRequest":{
+        "validityPeriod":{
+            "start": "2021-01-01T00:00:00+00:00",
+            "end": "2021-02-01T00:00:00+00:00"
+        }
+    },
+    "medicationReference":{
+        "reference": "Medication/20"
+    },
+    "dosageInstruction":[
+        {
+            "text": "<<Test Dosage Text>>",
+            "patientInstruction": "<<Test Patient Instruction>>"
+        }
+    ],
+    "recorder":{
+        "reference": "Organization/2"
+    },
+    "basedOn": [
+        {
+            "reference": "MedicationRequest/D66D84C9-C073-4EDF-8C2C-F309A83C3DC7"
+        }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-xml-escaped-text-values.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/medication-statement-with-xml-escaped-text-values.xml
@@ -1,0 +1,70 @@
+<component typeCode="COMP">
+    <MedicationStatement classCode="SBADM" moodCode="INT">
+        <id root="394559384658936"/>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <low value="20210101000000"/><high value="20210201000000"/>
+        </effectiveTime>
+        <availabilityTime value="20210101000000"/>
+        <consumable typeCode="CSM">
+            <manufacturedProduct classCode="MANU">
+                <manufacturedMaterial determinerCode="KIND" classCode="MMAT">
+                    <code code="430127000" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Oral Form Oxycodone (product)">
+                    </code>
+                </manufacturedMaterial>
+            </manufacturedProduct>
+        </consumable>
+        <component typeCode="COMP">
+            <ehrSupplyAuthorise>
+                <id root="394559384658936"/>
+                <code code="394823007" displayName="NHS Prescription" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <low value="20210101000000"/><high value="20210201000000"/>
+                </effectiveTime>
+                <availabilityTime value="20210101000000"/>
+                <repeatNumber value="0"/>
+                <quantity value="1" unit="1">
+                    <translation value="1">
+                        <originalText>Unk UoM</originalText>
+                    </translation>
+                </quantity>
+                <pertinentInformation typeCode="PERT">
+                    <pertinentSupplyAnnotation>
+                        <text>Patient Instruction: &lt;&lt;Test Patient Instruction&gt;&gt;</text>
+                    </pertinentSupplyAnnotation>
+                </pertinentInformation>
+            </ehrSupplyAuthorise>
+        </component>
+        <component typeCode="COMP">
+            <ehrSupplyDiscontinue classCode="SPLY" moodCode="RQO">
+                <id root="394559384658936"/>
+                <code nullFlavor="UNK">
+                    <originalText>&lt;&lt;Test Code Text&gt;&gt;</originalText>
+                </code>
+                <statusCode code="COMPLETE"/>
+                <availabilityTime value="20100118143316"/>
+                <reversalOf typeCode="REV">
+                    <priorMedicationRef moodCode="ORD" classCode="SBADM">
+                        <id root="394559384658936"/>
+                    </priorMedicationRef>
+                </reversalOf>
+                <pertinentInformation typeCode="PERT">
+                    <pertinentSupplyAnnotation classCode="OBS" moodCode="EVN">
+                        <text>&lt;&lt;Test Code Text&gt;&gt;</text>
+                    </pertinentSupplyAnnotation>
+                </pertinentInformation>
+            </ehrSupplyDiscontinue>
+        </component>
+        <pertinentInformation typeCode="PERT">
+            <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                <text>&lt;&lt;Test Dosage Text&gt;&gt;</text>
+            </pertinentMedicationDosage>
+        </pertinentInformation>
+        <Participant typeCode="AUT" contextControlCode="OP">
+            <agentRef classCode="AGNT">
+                <id root="394559384658936"/>
+            </agentRef>
+        </Participant>
+    </MedicationStatement>
+</component>


### PR DESCRIPTION


## What

* Update template used when mapping `MedicationStatements` to XML escape any user provided text field,
* Add test for user provided text fields when mapping `MedicationRequest` to `MedicationStatement`.
* Add XML / JSON for the above tests.

## Why

When sending an outbound GP2GP Request, the request would fail if the provided `medicationStatement.extension.extension.valueCodeableConcept.text` contained special characters as these were not being escaped when mapping to `ehrSupplyDiscontinue / pertinentInformation / pertinentSupplyAnnotation / text`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
