### PR TITLE
Remove new lines from ConfidentialityCode tag

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/service/ConfidentialityService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/service/ConfidentialityService.java
@@ -15,12 +15,9 @@ import java.util.Optional;
 public class ConfidentialityService {
     private static final String REDACTION_CODE_SYSTEM = "http://hl7.org/fhir/v3/ActCode";
     public static final String NOPAT = "NOPAT";
-    private static final String REDACTION_CONFIDENTIALITY_CODE = """
-        <confidentialityCode
-            code="NOPAT"
-            codeSystem="2.16.840.1.113883.4.642.3.47"
-            displayName="no disclosure to patient, family or caregivers without attending provider's authorization"
-        />""";
+    public static final String REDACTION_CONFIDENTIALITY_CODE = "<confidentialityCode code=\"NOPAT\" "
+                        + "codeSystem=\"2.16.840.1.113883.4.642.3.47\" "
+                        + "displayName=\"no disclosure to patient, family or caregivers without attending provider's authorization\" />";
 
     private final RedactionsContext redactionsContext;
 

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/common/service/ConfidentialityServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/common/service/ConfidentialityServiceTest.java
@@ -96,15 +96,10 @@ public class ConfidentialityServiceTest {
 
         var confidentialityCode = confidentialityService.generateConfidentialityCode(resource);
 
-        assertThat(confidentialityCode)
-            .isPresent();
+        assertThat(confidentialityCode).isPresent();
         assertThat(confidentialityCode.get())
-            .isEqualTo("""
-                <confidentialityCode
-                    code="NOPAT"
-                    codeSystem="2.16.840.1.113883.4.642.3.47"
-                    displayName="no disclosure to patient, family or caregivers without attending provider's authorization"
-                />"""
-            );
+            .isEqualTo(new String("<confidentialityCode code=\"NOPAT\" "
+                      + "codeSystem=\"2.16.840.1.113883.4.642.3.47\" "
+                      + "displayName=\"no disclosure to patient, family or caregivers without attending provider's authorization\" />"));
     }
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AllergyStructureMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AllergyStructureMapperTest.java
@@ -128,12 +128,9 @@ public class AllergyStructureMapperTest {
         + "expected-output-allergy-structure-22.xml";
     private static final String COMMON_ID = "6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73";
 
-    private static final String CONFIDENTIALITY_CODE = """
-        <confidentialityCode
-            code="NOPAT"
-            codeSystem="2.16.840.1.113883.4.642.3.47"
-            displayName="no disclosure to patient, family or caregivers without attending provider's authorization"
-        />""";
+    public static final String CONFIDENTIALITY_CODE = "<confidentialityCode code=\"NOPAT\" "
+                      + "codeSystem=\"2.16.840.1.113883.4.642.3.47\" "
+                      + "displayName=\"no disclosure to patient, family or caregivers without attending provider's authorization\" />";
 
     @Mock
     private RandomIdGeneratorService randomIdGeneratorService;

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/ConfidentialityCodeUtility.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/ConfidentialityCodeUtility.java
@@ -10,12 +10,9 @@ public final class ConfidentialityCodeUtility {
     private ConfidentialityCodeUtility() { }
     public static final String NOPAT = "NOPAT";
     public static final String NOSCRUB = "NOSCRUB";
-    public static final String NOPAT_HL7_CONFIDENTIALITY_CODE = """
-        <confidentialityCode
-            code="NOPAT"
-            codeSystem="2.16.840.1.113883.4.642.3.47"
-            displayName="no disclosure to patient, family or caregivers without attending provider's authorization" />
-        """;
+    public static final String NOPAT_HL7_CONFIDENTIALITY_CODE = "<confidentialityCode code=\"NOPAT\" "
+        + "codeSystem=\"2.16.840.1.113883.4.642.3.47\" "
+        + "displayName=\"no disclosure to patient, family or caregivers without attending provider's authorization\" />";
 
     public static <R extends DomainResource> String getSecurityCodeFromResource(R resource) {
         return resource.getMeta()


### PR DESCRIPTION
SystmOne are opinionated about this.

## What

Confidentiality code format fix

## Why

TPP advised us that that there should be no new line between 'confidentiality code' tag and the next tag

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
