### PR TITLE
Add NOPAT to Conditions within the "Large Patient Record" Wiremock scenario

### DIFF
--- a/wiremock/stubs/__files/correctPatientStructuredRecordLargePayload.json
+++ b/wiremock/stubs/__files/correctPatientStructuredRecordLargePayload.json
@@ -7445,7 +7445,12 @@
                     "profile":
                     [
                         "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
-                    ]
+                    ],
+                    "security": [{
+                        "system":"http://hl7.org/fhir/v3/ActCode",
+                        "code":"NOPAT",
+                        "display":"no disclosure to patient, family or caregivers without attending provider's authorization"
+                    }]
                 },
                 "extension":
                 [
@@ -15144,7 +15149,12 @@
                     "profile":
                     [
                         "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
-                    ]
+                    ],
+                    "security": [{
+                        "system":"http://hl7.org/fhir/v3/ActCode",
+                        "code":"NOPAT",
+                        "display":"no disclosure to patient, family or caregivers without attending provider's authorization"
+                    }]
                 },
                 "extension":
                 [
@@ -16899,7 +16909,12 @@
                     "profile":
                     [
                         "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-ProblemHeader-Condition-1"
-                    ]
+                    ],
+                    "security": [{
+                        "system":"http://hl7.org/fhir/v3/ActCode",
+                        "code":"NOPAT",
+                        "display":"no disclosure to patient, family or caregivers without attending provider's authorization"
+                    }]
                 },
                 "extension":
                 [


### PR DESCRIPTION
## What

Conditions with NOPAT added to them:

- ImmunisationsProblem - No ActualProblem extension
- Problem-A-Anxiety-With-Depression - An ActualProblem related to Observation/Consultation1-Topic1-Category-History-Observation-2
- MedicationProblem - No ActualProblem extension

Swollen Legs condition remains without any Security labelling.

## Why

To help test the adaptor E2E with incumbents

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
