### PR TITLE
AllergyMapper: Add confidentialityCode to ObservationStatement

### DIFF
--- a/service/src/main/resources/templates/ehr_allergy_structure_template.mustache
+++ b/service/src/main/resources/templates/ehr_allergy_structure_template.mustache
@@ -19,6 +19,9 @@
                     {{{effectiveTime}}}
                 </effectiveTime>
                 {{{availabilityTime}}}
+                {{#confidentialityCode}}
+                    {{{confidentialityCode}}}
+                {{/confidentialityCode}}
                 <pertinentInformation typeCode="PERT">
                     <sequenceNumber value="+1"/>
                     <pertinentAnnotation classCode="OBS" moodCode="EVN">

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AllergyStructureMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/AllergyStructureMapperTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.util.StringUtils;
 import uk.nhs.adaptors.gp2gp.common.service.ConfidentialityService;
 import uk.nhs.adaptors.gp2gp.common.service.FhirParseService;
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
@@ -248,6 +249,9 @@ public class AllergyStructureMapperTest {
         final var message = allergyStructureMapper.mapAllergyIntoleranceToAllergyStructure(allergyIntolerance);
 
         assertThat(message).contains(CONFIDENTIALITY_CODE);
+        assertThat(StringUtils.countOccurrencesOf(message, CONFIDENTIALITY_CODE))
+            .withFailMessage("<confidentialityCode /> should appear within both the CompoundStatement and ObservationStatement")
+            .isEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
## Why

Incumbents don't appear to be accepting the confidentialityCode as it is currently on the CompoundStatement.

## Type of change

Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
