### PR TITLE
Add NOPAT to DocumentReference Wiremock stubs

### DIFF
--- a/wiremock/stubs/__files/correctPatientStructuredRecordResponseAbsentAttachments.json
+++ b/wiremock/stubs/__files/correctPatientStructuredRecordResponseAbsentAttachments.json
@@ -498,7 +498,12 @@
                     "versionId": "8017752596891037527",
                     "profile": [
                         "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DocumentReference-1"
-                    ]
+                    ],
+                    "security": [{
+                        "system":"http://hl7.org/fhir/v3/ActCode",
+                        "code":"NOPAT",
+                        "display":"no disclosure to patient, family or caregivers without attending provider's authorization"
+                    }]
                 },
                 "identifier": [
                     {
@@ -545,6 +550,18 @@
                         "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DocumentReference-1"
                     ]
                 },
+                "securityLabel": [
+                    {
+                        "coding": [
+                            {
+                                "system": "http://hl7.org/fhir/v3/ActCode",
+                                "code": "NOPAT",
+                                "display": "no disclosure to patient, family or caregivers without attending provider's authorization"
+                            }
+                        ],
+                        "text": "no disclosure to patient, family or caregivers without attending provider's authorization"
+                    }
+                ],
                 "identifier": [
                     {
                         "system": "https://EMISWeb/A82038",


### PR DESCRIPTION
## What

There are two ways a DocumentReference can be given a NOPAT marking according to the GP2GP spec, this PR introduces examples for both.

## Why

This will allow us to more easily test the behaviour of incumbent systems E2E.

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
