### PR TITLE
Wiremock Investigations: Move NOPAT between Specimens

### DIFF
--- a/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP9.json
+++ b/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP9.json
@@ -11153,12 +11153,7 @@
                 "meta": {
                     "profile": [
                         "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Specimen-1"
-                    ],
-                    "security": [{
-                      "system":"http://hl7.org/fhir/v3/ActCode",
-                      "code":"NOPAT",
-                      "display":"no disclosure to patient, family or caregivers without attending provider's authorization"
-                    }]
+                    ]
                 },
                 "identifier": [
                     {
@@ -12709,7 +12704,12 @@
                 "meta": {
                     "profile": [
                         "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Specimen-1"
-                    ]
+                    ],
+                    "security": [{
+                      "system":"http://hl7.org/fhir/v3/ActCode",
+                      "code":"NOPAT",
+                      "display":"no disclosure to patient, family or caregivers without attending provider's authorization"
+                    }]
                 },
                 "identifier": [
                     {


### PR DESCRIPTION
## Why

Current specimen is part of the same investigation which has a comment note with NOPAT.

By moving the specimen with NOPAT to a separate investigation we help make the testing simpler.

## Type of change

Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users