### PR TITLE
Add exception for unrecognised and uncoded prescription types

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementExtractor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementExtractor.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.BaseExtension;
 import org.hl7.fhir.dstu3.model.CodeableConcept;
-import org.hl7.fhir.dstu3.model.Coding;
 import org.hl7.fhir.dstu3.model.DateTimeType;
 import org.hl7.fhir.dstu3.model.Extension;
 import org.hl7.fhir.dstu3.model.MedicationRequest;
@@ -34,7 +33,6 @@ public class MedicationStatementExtractor {
         TemplateUtils.loadTemplate("in_fulfilment_of_template.mustache");
 
     private static final String MEDICATION_QUANTITY_TEXT_URL = "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationQuantityText-1";
-    private static final String PRESCRIPTION_TYPE_URL = "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1";
     private static final String REPEAT_INFORMATION_URL = "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationRepeatInformation-1";
     private static final String NUM_OF_REPEAT_PRESCRIPTIONS_ALLOWED_URL = "numberOfRepeatPrescriptionsAllowed";
     private static final String DEFAULT_REPEAT_VALUE = "1";
@@ -43,7 +41,7 @@ public class MedicationStatementExtractor {
     private static final String STATUS_CHANGE_URL = "statusChangeDate";
     private static final String AVAILABILITY_TIME_VALUE_TEMPLATE = "<availabilityTime value=\"%s\"/>";
     private static final String DEFAULT_QUANTITY_TEXT = "Unk UoM";
-    private static final String NO_INFO_AVAILABLE = "No information available";
+
     private static final String PRESCRIBING_AGENCY_EXTENSION_URL = "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescribingAgency-1";
 
     public static String extractDispenseRequestQuantityText(MedicationRequest medicationRequest) {
@@ -66,25 +64,6 @@ public class MedicationStatementExtractor {
             .map(Extension::getValue)
             .map(Objects::toString)
             .orElse(DEFAULT_QUANTITY_TEXT);
-    }
-
-    public static String extractPrescriptionTypeCode(MedicationRequest medicationRequest) {
-        return filterExtensionByUrl(medicationRequest, PRESCRIPTION_TYPE_URL)
-            .map(Extension::getValue)
-            .map(CodeableConcept.class::cast)
-            .map(CodeableConcept::getCodingFirstRep)
-            .map(Coding::getCode)
-            .orElse(StringUtils.EMPTY);
-    }
-
-    public static boolean prescriptionTypeTextIsNoInfoAvailable(MedicationRequest medicationRequest) {
-        var prescriptionTypeText =  filterExtensionByUrl(medicationRequest, PRESCRIPTION_TYPE_URL)
-            .map(Extension::getValue)
-            .map(CodeableConcept.class::cast)
-            .map(CodeableConcept::getText)
-            .orElse(StringUtils.EMPTY);
-
-        return NO_INFO_AVAILABLE.equals(prescriptionTypeText);
     }
 
     public static String extractRepeatValue(MedicationRequest medicationRequest) {

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapperTest.java
@@ -386,6 +386,23 @@ public class MedicationStatementMapperTest {
         assertThat(exception.getMessage()).isEqualTo("Could not resolve Prescription Type of `invalid-type` in MedicationRequest/789");
     }
 
+    @Test
+    void When_MedicationRequestPlanHasUnrecognisedUncodedPrescriptionType_Expect_EhrMapperExceptionThrown() {
+        final var jsonInput = ResourceTestFileUtils.getFileContent(
+            TEST_FILE_DIRECTORY + "mr-plan-with-unrecognised-uncoded-prescription-type.json"
+        );
+        final var parsedMedicationRequest = new FhirParseService()
+            .parseResource(jsonInput, MedicationRequest.class);
+
+        var exception = assertThrows(
+            EhrMapperException.class,
+            () -> medicationStatementMapper.mapMedicationRequestToMedicationStatement(parsedMedicationRequest));
+
+        assertThat(exception.getMessage())
+            .isEqualTo("Could not resolve Prescription Type with text of `Some medical information` in MedicationRequest/789");
+
+    }
+
     private void assertXmlIsEqual(String outputString, String expected) {
 
         Diff diff = DiffBuilder.compare(outputString).withTest(expected)

--- a/service/src/test/resources/ehr/mapper/medication_request/mr-plan-with-unrecognised-uncoded-prescription-type.json
+++ b/service/src/test/resources/ehr/mapper/medication_request/mr-plan-with-unrecognised-uncoded-prescription-type.json
@@ -1,0 +1,51 @@
+{
+    "resourceType": "MedicationRequest",
+    "id": "789",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+        ]
+    },
+    "extension": [
+        {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-PrescriptionType-1",
+            "valueCodeableConcept": {
+                "text": "Some medical information"
+            }
+        }
+    ],
+    "status": "completed",
+    "intent": "plan",
+    "medicationReference": {
+        "reference": "Medication/20"
+    },
+    "authoredOn": "2022-10-04",
+    "recorder": {
+        "reference": "Practitioner/1332aa9c-28d6-11eb-adc1-0242ac120002"
+    },
+    "requester": {
+        "agent": {
+            "reference": "Organization/F85003"
+        }
+    },
+    "dosageInstruction": [
+        {
+            "text": "One puff as needed. Max 10 doses per day"
+        }
+    ],
+    "dispenseRequest": {
+        "validityPeriod": {
+            "start": "2022-10-04",
+            "end": "2022-11-01"
+        },
+        "quantity": {
+            "value": 1,
+            "unit": "dose"
+        },
+        "expectedSupplyDuration": {
+            "value": 28,
+            "system": "http://unitsofmeasure.org",
+            "code": "d"
+        }
+    }
+}


### PR DESCRIPTION

## What

* Add exception for the case where prescription type is unrecognised (the text value is present but is not "No information available").
* Add unit test and test file for the above change.
* Remove now unused methods and constants from `MedicationStatementExtractor`.

## Why

Ensure compliance in response to [GP Connect 1.6.2 Changelog](https://simplifier.net/guide/gp-connect-access-record-structured/Home/Introduction/Release-notes?version=current#1.6.2)

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
