### PR TITLE
NIAD-3304: Add CodeSystemUtil for mapping between code systems

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/utils/CodeSystemsUtil.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/utils/CodeSystemsUtil.java
@@ -1,0 +1,21 @@
+package uk.nhs.adaptors.gp2gp.ehr.utils;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class CodeSystemsUtil {
+
+    private static final Map<String, String> SYSTEM_CODES = Map.of(
+        "http://snomed.info/sct", "2.16.840.1.113883.2.1.3.2.4.15",
+        "https://fhir.hl7.org.uk/Id/egton-codes", "2.16.840.1.113883.2.1.6.3",
+        "http://read.info/readv2", "2.16.840.1.113883.2.1.6.2",
+        "http://read.info/ctv3", "2.16.840.1.113883.2.1.3.2.4.14"
+    );
+
+    public static String getHl7code(String fhirCodeSystem) {
+        return SYSTEM_CODES.getOrDefault(fhirCodeSystem, fhirCodeSystem);
+    }
+}

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/CodeSystemUtilTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/CodeSystemUtilTest.java
@@ -31,8 +31,8 @@ public class CodeSystemUtilTest {
 
     @Test
     void When_FhirCodeSystemIsUnknown_Expect_FhirCodeSystemIsProvided() {
-        var hl7Code = CodeSystemsUtil.getHl7code("1.2.3.4.5.6");
+        var hl7Code = CodeSystemsUtil.getHl7code("https://unknown.code/system");
 
-        assertThat(hl7Code).isEqualTo("1.2.3.4.5.6");
+        assertThat(hl7Code).isEqualTo("https://unknown.code/system");
     }
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/CodeSystemUtilTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/CodeSystemUtilTest.java
@@ -1,0 +1,38 @@
+package uk.nhs.adaptors.gp2gp.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import uk.nhs.adaptors.gp2gp.ehr.utils.CodeSystemsUtil;
+
+import java.util.stream.Stream;
+
+public class CodeSystemUtilTest {
+
+    private static Stream<Arguments> knownCodeSystems() {
+        return Stream.of(
+            Arguments.of("http://snomed.info/sct", "2.16.840.1.113883.2.1.3.2.4.15"),
+            Arguments.of("https://fhir.hl7.org.uk/Id/egton-codes", "2.16.840.1.113883.2.1.6.3"),
+            Arguments.of("http://read.info/readv2", "2.16.840.1.113883.2.1.6.2"),
+            Arguments.of("http://read.info/ctv3", "2.16.840.1.113883.2.1.3.2.4.14")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("knownCodeSystems")
+    void When_FhirCodeSystemIsKnown_Expect_CorrectHl7Code(String fhirCodeSystem, String expectedHl7Code) {
+        var hl7Code = CodeSystemsUtil.getHl7code(fhirCodeSystem);
+
+        assertThat(hl7Code).isEqualTo(expectedHl7Code);
+    }
+
+    @Test
+    void When_FhirCodeSystemIsUnknown_Expect_FhirCodeSystemIsProvided() {
+        var hl7Code = CodeSystemsUtil.getHl7code("1.2.3.4.5.6");
+
+        assertThat(hl7Code).isEqualTo("1.2.3.4.5.6");
+    }
+}


### PR DESCRIPTION
## What

*  Add CodeSystemUtil to map from JSON FHIR codes (urls) to HL7 XML codes (OIDs).
*  Add functionality to ensure that the JSON FHIR Code is preserved when the JSON FHIR Code is not a known code system.
* Add unit tests for the above functionality.

## Why

When implementing the changes required in NIAD-3304, when mapping a codeable concept we will no longer only be mapping SNOMEDCT codes, but will also need to preserve codes from other codes systems.  When completing this part of the work for the GP2GP Request adaptor, a number of code types were identified as known codes.

These FHIR code systems and corresponding HL7 OIDs are listed below:

* `http://snomed.info/sct` -> `2.16.840.1.113883.2.1.3.2.4.15`
* `https://fhir.hl7.org.uk/Id/egton-codes` -> `2.16.840.1.113883.2.1.6.3`
* `http://read.info/readv2` ->  `2.16.840.1.113883.2.1.6.2`
* `http://read.info/ctv3` -> `2.16.840.1.113883.2.1.3.2.4.14`

When handling non-SNOMEDCT codes we will need to be able to map from the FHIR code system to the HL7 OID for the known code systems above, and in the case of unknown FHIR code systems, to preserve the original code system.

This change introduces a new static class `CodeSystemUtils` to facilitate this functionality when developing out the rest of the work required for NIAD-3304.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

