### PR TITLE
NIAD-3304: Add functionality for medication codeable concepts to include non-SNOMEDCT codes

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
@@ -103,9 +103,7 @@ public class CodeableConceptCdMapper {
             .or(() -> Optional.ofNullable(snomedCodeCoding.get().getDisplay()));
         displayName.ifPresent(builder::mainDisplayName);
 
-        if (codeableConcept.hasText()) {
-            builder.mainOriginalText(codeableConcept.getText());
-        }
+        builder.mainOriginalText(codeableConcept.getText());
 
         builder.translations(getNonSnomedCodeCodings(codeableConcept));
         return TemplateUtils.fillTemplate(CODEABLE_CONCEPT_CD_TEMPLATE, builder.build());

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
@@ -81,35 +81,33 @@ public class CodeableConceptCdMapper {
     // we have agreed to use the Concept ID rather than Description Id for medications which will avoided the degradation.
     public String mapCodeableConceptForMedication(CodeableConcept codeableConcept) {
         var builder = CodeableConceptCdTemplateParameters.builder();
-        var mainCode = getSnomedCodeCoding(codeableConcept);
+        var snomedCodeCoding = getSnomedCodeCoding(codeableConcept);
 
-        builder.nullFlavor(mainCode.isEmpty());
-
-        if (mainCode.isPresent()) {
-            var extension = retrieveDescriptionExtension(mainCode.get())
-                .map(Extension::getExtension)
-                .orElse(Collections.emptyList());
-
-            builder.mainCodeSystem(SNOMED_SYSTEM_CODE);
-
-            Optional<String> code = Optional.ofNullable(mainCode.get().getCode());
-            code.ifPresent(builder::mainCode);
-
-            Optional<String> displayName = extension.stream()
-                .filter(displayExtension -> DESCRIPTION_DISPLAY.equals(displayExtension.getUrl()))
-                .map(description -> description.getValue().toString())
-                .findFirst()
-                .or(() -> Optional.ofNullable(mainCode.get().getDisplay()));
-            displayName.ifPresent(builder::mainDisplayName);
-
-            if (codeableConcept.hasText()) {
-                builder.mainOriginalText(codeableConcept.getText());
-            }
-        } else {
-            var originalText = findOriginalText(codeableConcept, mainCode);
-            originalText.ifPresent(builder::mainOriginalText);
+        if (snomedCodeCoding.isEmpty()) {
+            return buildNullFlavourCodeableConceptCd(codeableConcept, snomedCodeCoding);
         }
 
+        var extension = retrieveDescriptionExtension(snomedCodeCoding.get())
+            .map(Extension::getExtension)
+            .orElse(Collections.emptyList());
+
+        builder.mainCodeSystem(SNOMED_SYSTEM_CODE);
+
+        Optional<String> code = Optional.ofNullable(snomedCodeCoding.get().getCode());
+        code.ifPresent(builder::mainCode);
+
+        Optional<String> displayName = extension.stream()
+            .filter(displayExtension -> DESCRIPTION_DISPLAY.equals(displayExtension.getUrl()))
+            .map(description -> description.getValue().toString())
+            .findFirst()
+            .or(() -> Optional.ofNullable(snomedCodeCoding.get().getDisplay()));
+        displayName.ifPresent(builder::mainDisplayName);
+
+        if (codeableConcept.hasText()) {
+            builder.mainOriginalText(codeableConcept.getText());
+        }
+
+        builder.translations(getNonSnomedCodeCodings(codeableConcept));
         return TemplateUtils.fillTemplate(CODEABLE_CONCEPT_CD_TEMPLATE, builder.build());
     }
 

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapperTest.java
@@ -131,7 +131,9 @@ public class MedicationStatementMapperTest {
             Arguments.of("mr-with-extension-status-reason-with-text.json", "medication-statement-with-status-reason-text.xml"),
             Arguments.of("mr-with-no-recorder-reference.json", "medication-statement-with-no-participant.xml"),
             Arguments.of("mr-with-invalid-recorder-resource-type.json", "medication-statement-with-no-participant.xml"),
-            Arguments.of("medication-request-special-character-in-code.json", "medication-statement-with-xml-escaped-text-values.xml")
+            Arguments.of("medication-request-special-character-in-code.json", "medication-statement-with-xml-escaped-text-values.xml"),
+            Arguments.of("mr-referencing-medication-with-non-snomed-codes.json", "ms-with-material-coding-containing-translations.xml"),
+            Arguments.of("mr-referencing-medication-with-no-snomed-code.json", "ms-with-material-coding-containing-null-flavor-code.xml")
         );
     }
 

--- a/service/src/test/resources/ehr/mapper/medication_request/fhir-bundle.json
+++ b/service/src/test/resources/ehr/mapper/medication_request/fhir-bundle.json
@@ -24,6 +24,51 @@
         },
         {
             "resource": {
+                "resourceType": "Medication",
+                "id": "21",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "430127000",
+                            "display": "Oral Form Oxycodone (product)"
+                        },
+                        {
+                            "system": "http://read.info/readv2",
+                            "code": "READ0",
+                            "display": "Display for Read V2"
+                        },
+                        {
+                            "system": "http://read.info/ctv3",
+                            "code": "READ1",
+                            "display": "Display for Read CTV3"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Medication",
+                "id": "22",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://read.info/readv2",
+                            "code": "READ0",
+                            "display": "Display for Read V2"
+                        },
+                        {
+                            "system": "http://read.info/ctv3",
+                            "code": "READ1",
+                            "display": "Display for Read CTV3"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
                 "resourceType":"MedicationRequest",
                 "id":"D66D84C9-C073-4EDF-8C2C-F309A83C3DC7",
                 "meta":{

--- a/service/src/test/resources/ehr/mapper/medication_request/mr-referencing-medication-with-no-snomed-code.json
+++ b/service/src/test/resources/ehr/mapper/medication_request/mr-referencing-medication-with-no-snomed-code.json
@@ -1,0 +1,59 @@
+{
+    "resourceType":"MedicationRequest",
+    "id":"3377543D-5B1B-4C4F-BFF6-9F7BC3A1C3B8",
+    "meta":{
+        "profile":[
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+        ]
+    },
+    "extension":[
+        {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationRepeatInformation-1",
+            "extension": [
+                {
+                    "url": "numberOfRepeatPrescriptionsAllowed",
+                    "valuePositiveInt": 12
+                },
+                {
+                    "url": "numberOfRepeatPrescriptionsIssued",
+                    "valuePositiveInt": 11
+                }
+            ]
+        }
+    ],
+    "identifier":[
+        {
+            "system":"https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+            "value":"f2489066-7082-11eb-bb13-00505692d4aa"
+        }
+    ],
+    "status":"active",
+    "intent":"order",
+    "medicationReference":{
+        "reference":"Medication/22"
+    },
+    "subject":{
+        "reference":"Patient/2"
+    },
+    "authoredOn":"2017-11-10T00:00:00+00:00",
+    "recorder":{
+        "reference":"Practitioner/1"
+    },
+    "dosageInstruction":[
+        {
+            "text":"1 tablet once a day",
+            "patientInstruction":"Take in morning"
+        }
+    ],
+    "dispenseRequest":{
+        "validityPeriod":{
+            "start":"2017-11-10T00:00:00+00:00",
+            "end":"2018-08-15T00:00:00+01:00"
+        }
+    },
+    "basedOn": [
+        {
+            "reference": "MedicationRequest/D66D84C9-C073-4EDF-8C2C-F309A83C3DC7"
+        }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/medication_request/mr-referencing-medication-with-non-snomed-codes.json
+++ b/service/src/test/resources/ehr/mapper/medication_request/mr-referencing-medication-with-non-snomed-codes.json
@@ -1,0 +1,59 @@
+{
+    "resourceType":"MedicationRequest",
+    "id":"3377543D-5B1B-4C4F-BFF6-9F7BC3A1C3B8",
+    "meta":{
+        "profile":[
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+        ]
+    },
+    "extension":[
+        {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationRepeatInformation-1",
+            "extension": [
+                {
+                    "url": "numberOfRepeatPrescriptionsAllowed",
+                    "valuePositiveInt": 12
+                },
+                {
+                    "url": "numberOfRepeatPrescriptionsIssued",
+                    "valuePositiveInt": 11
+                }
+            ]
+        }
+    ],
+    "identifier":[
+        {
+            "system":"https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+            "value":"f2489066-7082-11eb-bb13-00505692d4aa"
+        }
+    ],
+    "status":"active",
+    "intent":"order",
+    "medicationReference":{
+        "reference":"Medication/21"
+    },
+    "subject":{
+        "reference":"Patient/2"
+    },
+    "authoredOn":"2017-11-10T00:00:00+00:00",
+    "recorder":{
+        "reference":"Practitioner/1"
+    },
+    "dosageInstruction":[
+        {
+            "text":"1 tablet once a day",
+            "patientInstruction":"Take in morning"
+        }
+    ],
+    "dispenseRequest":{
+        "validityPeriod":{
+            "start":"2017-11-10T00:00:00+00:00",
+            "end":"2018-08-15T00:00:00+01:00"
+        }
+    },
+    "basedOn": [
+        {
+            "reference": "MedicationRequest/D66D84C9-C073-4EDF-8C2C-F309A83C3DC7"
+        }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/medication_request/ms-with-material-coding-containing-null-flavor-code.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/ms-with-material-coding-containing-null-flavor-code.xml
@@ -1,0 +1,52 @@
+<component typeCode="COMP">
+    <MedicationStatement classCode="SBADM" moodCode="ORD">
+        <id root="394559384658936"/>
+        <statusCode code="ACTIVE"/>
+        <effectiveTime>
+            <low value="20171110000000"/><high value="20180815000000"/>
+        </effectiveTime>
+        <availabilityTime value="20171110000000"/>
+        <consumable typeCode="CSM">
+            <manufacturedProduct classCode="MANU">
+                <manufacturedMaterial determinerCode="KIND" classCode="MMAT">
+                    <code nullFlavor="UNK">
+                        <originalText>Display for Read V2</originalText>
+                    </code>
+                </manufacturedMaterial>
+            </manufacturedProduct>
+        </consumable>
+        <component typeCode="COMP">
+            <ehrSupplyPrescribe>
+                <id root="394559384658936"/>
+                <code code="394823007" displayName="NHS Prescription" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                <statusCode code="ACTIVE"/>
+                <availabilityTime value="20171110000000"/>
+                <quantity value="1" unit="1">
+                    <translation value="1">
+                        <originalText>Unk UoM</originalText>
+                    </translation>
+                </quantity>
+                <inFulfillmentOf typeCode="FLFS">
+    <priorMedicationRef moodCode="INT">
+        <id root="394559384658936"/>
+    </priorMedicationRef>
+</inFulfillmentOf>
+                <pertinentInformation typeCode="PERT">
+                    <pertinentSupplyAnnotation>
+                        <text>Patient Instruction: Take in morning</text>
+                    </pertinentSupplyAnnotation>
+                </pertinentInformation>
+            </ehrSupplyPrescribe>
+        </component>
+        <pertinentInformation typeCode="PERT">
+            <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                <text>1 tablet once a day</text>
+            </pertinentMedicationDosage>
+        </pertinentInformation>
+        <Participant typeCode="AUT" contextControlCode="OP">
+    <agentRef classCode="AGNT">
+        <id root="394559384658936"/>
+    </agentRef>
+</Participant>
+    </MedicationStatement>
+</component>

--- a/service/src/test/resources/ehr/mapper/medication_request/ms-with-material-coding-containing-translations.xml
+++ b/service/src/test/resources/ehr/mapper/medication_request/ms-with-material-coding-containing-translations.xml
@@ -1,0 +1,53 @@
+<component typeCode="COMP">
+    <MedicationStatement classCode="SBADM" moodCode="ORD">
+        <id root="394559384658936"/>
+        <statusCode code="ACTIVE"/>
+        <effectiveTime>
+            <low value="20171110000000"/><high value="20180815000000"/>
+        </effectiveTime>
+        <availabilityTime value="20171110000000"/>
+        <consumable typeCode="CSM">
+            <manufacturedProduct classCode="MANU">
+                <manufacturedMaterial determinerCode="KIND" classCode="MMAT">
+                    <code code="430127000" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Oral Form Oxycodone (product)">
+                        <translation code="READ0" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Display for Read V2" />
+                        <translation code="READ1" codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="Display for Read CTV3" />
+                    </code>
+                </manufacturedMaterial>
+            </manufacturedProduct>
+        </consumable>
+        <component typeCode="COMP">
+            <ehrSupplyPrescribe>
+                <id root="394559384658936"/>
+                <code code="394823007" displayName="NHS Prescription" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+                <statusCode code="ACTIVE"/>
+                <availabilityTime value="20171110000000"/>
+                <quantity value="1" unit="1">
+                    <translation value="1">
+                        <originalText>Unk UoM</originalText>
+                    </translation>
+                </quantity>
+                <inFulfillmentOf typeCode="FLFS">
+    <priorMedicationRef moodCode="INT">
+        <id root="394559384658936"/>
+    </priorMedicationRef>
+</inFulfillmentOf>
+                <pertinentInformation typeCode="PERT">
+                    <pertinentSupplyAnnotation>
+                        <text>Patient Instruction: Take in morning</text>
+                    </pertinentSupplyAnnotation>
+                </pertinentInformation>
+            </ehrSupplyPrescribe>
+        </component>
+        <pertinentInformation typeCode="PERT">
+            <pertinentMedicationDosage classCode="SBADM" moodCode="RMD">
+                <text>1 tablet once a day</text>
+            </pertinentMedicationDosage>
+        </pertinentInformation>
+        <Participant typeCode="AUT" contextControlCode="OP">
+    <agentRef classCode="AGNT">
+        <id root="394559384658936"/>
+    </agentRef>
+</Participant>
+    </MedicationStatement>
+</component>


### PR DESCRIPTION

## What

* Update `fhir-bundle.json` to add `Medication` resources for non-snomed codes, and additionally for when no SNOMED code is present.
* Add test to ensure that translations are added when a `Medication` contains a snomed code and non-snomed codes.
* Add test to ensure that a `nullFlavor="UNK"` coding block is created when no snomed codes are present in a `Medication`.
* Add test files for the above tests.

## Why

The GP2GP Sending Adaptor does not currently preserve non-SNOMEDCT codes when mapping CodeableConcepts.

The GP2GP Request Adaptor does preserve this codes when a SNOMEDCT code is also present in the coding block.

It is necessary as part of FRA that these are preserved when transferring a patient out of NME system.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

This is the first part of the change and documentation / change log will be updated once work is complete.
