### PR TITLE
NIAD-3304: GP2GP Sending Adaptor not preserving legacy codes when mapping allergies

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
@@ -353,13 +353,11 @@ public class CodeableConceptCdMapper {
             return Optional.empty();
         }
 
-        if (!allergyIntoleranceClinicalStatus.toCode().isEmpty()) {
-            if (RESOLVED_CLINICAL_STATUS.equals(allergyIntoleranceClinicalStatus.toCode())) {
-                return getOriginalTextForResolvedAllergy(codeableConcept, coding.get());
-            }
-            if (ACTIVE_CLINICAL_STATUS.equals(allergyIntoleranceClinicalStatus.toCode())) {
-                return getOriginalTextForActiveAllergy(coding.get());
-            }
+        if (RESOLVED_CLINICAL_STATUS.equals(allergyIntoleranceClinicalStatus.toCode())) {
+            return getOriginalTextForResolvedAllergy(codeableConcept, coding.get());
+        }
+        if (ACTIVE_CLINICAL_STATUS.equals(allergyIntoleranceClinicalStatus.toCode())) {
+            return getOriginalTextForActiveAllergy(coding.get());
         }
 
         return CodeableConceptMappingUtils.extractTextOrCoding(codeableConcept);

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
@@ -103,6 +103,7 @@ public class CodeableConceptCdMapper {
 
         if (ACTIVE_CLINICAL_STATUS.equals(allergyIntoleranceClinicalStatus.toCode())) {
             builder.mainCodeSystem(SNOMED_SYSTEM_CODE);
+            builder.translations(getNonSnomedCodeCodings(codeableConcept));
         } else {
             builder.nullFlavor(true);
         }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
@@ -38,7 +38,6 @@ public class CodeableConceptCdMapper {
     private static final String FIXED_ACTUAL_PROBLEM_CODE = "55607006";
     private static final String PROBLEM_DISPLAY_NAME = "Problem";
     private static final String ACTIVE_CLINICAL_STATUS = "active";
-    private static final String RESOLVED_CLINICAL_STATUS = "resolved";
     private static final String PRESCRIBING_AGENCY_GP_PRACTICE_CODE = "prescribed-at-gp-practice";
     private static final String PRESCRIBING_AGENCY_PREVIOUS_PRACTICE_CODE = "prescribed-by-previous-practice";
     private static final String PRESCRIBING_AGENCY_ANOTHER_ORGANISATION_CODE = "prescribed-by-another-organisation";
@@ -353,9 +352,6 @@ public class CodeableConceptCdMapper {
             return Optional.empty();
         }
 
-        if (RESOLVED_CLINICAL_STATUS.equals(allergyIntoleranceClinicalStatus.toCode())) {
-            return getOriginalTextForResolvedAllergy(codeableConcept, coding.get());
-        }
         if (ACTIVE_CLINICAL_STATUS.equals(allergyIntoleranceClinicalStatus.toCode())) {
             return getOriginalTextForActiveAllergy(coding.get());
         }
@@ -376,35 +372,6 @@ public class CodeableConceptCdMapper {
             if (originalText.isPresent()) {
                 return originalText;
             }
-        }
-
-        return Optional.empty();
-    }
-
-    private Optional<String> getOriginalTextForResolvedAllergy(CodeableConcept codeableConcept, Coding coding) {
-
-        if (codeableConcept.hasText()) {
-            return Optional.ofNullable(codeableConcept.getText());
-        }
-
-        var extension = retrieveDescriptionExtension(coding);
-        if (extension.isEmpty()) {
-            return coding.hasDisplay()
-                ? Optional.ofNullable(coding.getDisplay())
-                : Optional.empty();
-        }
-
-        Optional<String> originalText = extension
-            .get()
-            .getExtension().stream()
-            .filter(displayExtension -> DESCRIPTION_DISPLAY.equals(displayExtension.getUrl()))
-            .map(extension1 -> extension1.getValue().toString())
-            .findFirst();
-
-        if (originalText.isPresent()) {
-            return originalText;
-        } else if (coding.hasDisplay()) {
-            return Optional.ofNullable(coding.getDisplay());
         }
 
         return Optional.empty();

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
@@ -3,6 +3,7 @@ package uk.nhs.adaptors.gp2gp.ehr.mapper;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BiFunction;
 
 import org.apache.commons.lang3.StringUtils;
 import org.hl7.fhir.dstu3.model.AllergyIntolerance;
@@ -51,10 +52,23 @@ public class CodeableConceptCdMapper {
     private static final String OTHER_CATEGORY_DESCRIPTION = "Other category";
 
     public String mapCodeableConceptToCd(CodeableConcept codeableConcept) {
+        return mapCodeableConcept(codeableConcept, this::getMainCode);
+    }
+
+    public String mapCodeableConceptForMedication(CodeableConcept codeableConcept) {
+        return mapCodeableConcept(
+            codeableConcept,
+            (descriptionExtensions, snomedCodeCoding) -> Optional.ofNullable(snomedCodeCoding.getCode()));
+    }
+
+    private String mapCodeableConcept(
+        CodeableConcept codeableConcept,
+        BiFunction<Optional<List<Extension>>, Coding, Optional<String>> getMainCodeFunction
+    ) {
         Optional<Coding> snomedCodeCoding = getSnomedCodeCoding(codeableConcept);
 
         if (snomedCodeCoding.isEmpty()) {
-            return buildNullFlavourCodeableConceptCd(codeableConcept, snomedCodeCoding);
+            return mapToNullFlavorCodeableConcept(codeableConcept);
         }
 
         var builder = CodeableConceptCdTemplateParameters.builder();
@@ -64,87 +78,60 @@ public class CodeableConceptCdMapper {
 
         builder.mainCodeSystem(SNOMED_SYSTEM_CODE);
 
-        var mainCode = getMainCode(descriptionExtensions, snomedCodeCoding.get());
-        mainCode.ifPresent(builder::mainCode);
-
         var mainDisplayName = getMainDisplayName(descriptionExtensions, snomedCodeCoding.get());
         mainDisplayName.ifPresent(builder::mainDisplayName);
 
         builder.mainOriginalText(codeableConcept.getText());
         builder.translations(getNonSnomedCodeCodings(codeableConcept));
 
+        var mainCode = getMainCodeFunction.apply(descriptionExtensions, snomedCodeCoding.get());
+        mainCode.ifPresent(builder::mainCode);
+
         return TemplateUtils.fillTemplate(CODEABLE_CONCEPT_CD_TEMPLATE, builder.build());
     }
 
-    // Medications are currently using D&T Codes rather than snomed codes but are being passed through as SNOMED codes which is
-    // creating a degradation on the receiving side. Until the types are configured correctly and agreed to a specification
-    // we have agreed to use the Concept ID rather than Description Id for medications which will avoided the degradation.
-    public String mapCodeableConceptForMedication(CodeableConcept codeableConcept) {
+    public String mapCodeableConceptToCdForAllergy(
+        CodeableConcept codeableConcept,
+        AllergyIntolerance.AllergyIntoleranceClinicalStatus allergyIntoleranceClinicalStatus
+    ) {
         var builder = CodeableConceptCdTemplateParameters.builder();
-        var snomedCodeCoding = getSnomedCodeCoding(codeableConcept);
+        Optional<Coding> snomedCodeCoding = getSnomedCodeCoding(codeableConcept);
 
         if (snomedCodeCoding.isEmpty()) {
-            return buildNullFlavourCodeableConceptCd(codeableConcept, snomedCodeCoding);
+            builder.nullFlavor(true);
+            return TemplateUtils.fillTemplate(CODEABLE_CONCEPT_CD_TEMPLATE, builder.build());
         }
 
-        var extension = retrieveDescriptionExtension(snomedCodeCoding.get())
-            .map(Extension::getExtension)
-            .orElse(Collections.emptyList());
+        if (ACTIVE_CLINICAL_STATUS.equals(allergyIntoleranceClinicalStatus.toCode())) {
+            builder.mainCodeSystem(SNOMED_SYSTEM_CODE);
+        } else {
+            builder.nullFlavor(true);
+        }
 
-        builder.mainCodeSystem(SNOMED_SYSTEM_CODE);
+        getAllergyMainCode(snomedCodeCoding.get()).ifPresent(builder::mainCode);
+        getCodingDisplayName(snomedCodeCoding.get()).ifPresent(builder::mainDisplayName);
 
-        Optional<String> code = Optional.ofNullable(snomedCodeCoding.get().getCode());
-        code.ifPresent(builder::mainCode);
+        if (codeableConcept.hasText()) {
+            builder.mainOriginalText(codeableConcept.getText());
+        } else {
+            var originalText = findOriginalTextForAllergy(codeableConcept, snomedCodeCoding, allergyIntoleranceClinicalStatus);
+            originalText.ifPresent(builder::mainOriginalText);
+        }
 
-        Optional<String> displayName = extension.stream()
-            .filter(displayExtension -> DESCRIPTION_DISPLAY.equals(displayExtension.getUrl()))
-            .map(description -> description.getValue().toString())
-            .findFirst()
-            .or(() -> Optional.ofNullable(snomedCodeCoding.get().getDisplay()));
-        displayName.ifPresent(builder::mainDisplayName);
-
-        builder.mainOriginalText(codeableConcept.getText());
-
-        builder.translations(getNonSnomedCodeCodings(codeableConcept));
         return TemplateUtils.fillTemplate(CODEABLE_CONCEPT_CD_TEMPLATE, builder.build());
     }
 
-    public String mapCodeableConceptToCdForAllergy(CodeableConcept codeableConcept, AllergyIntolerance.AllergyIntoleranceClinicalStatus
-        allergyIntoleranceClinicalStatus) {
-        var builder = CodeableConceptCdTemplateParameters.builder();
-        var mainCode = getSnomedCodeCoding(codeableConcept);
+    private static Optional<String> getCodingDisplayName(Coding snomedCodeCoding) {
+        return Optional.ofNullable(snomedCodeCoding.getDisplay());
+    }
 
-        builder.nullFlavor(mainCode.isEmpty());
-
-        if (mainCode.isPresent()) {
-            var extension = retrieveDescriptionExtension(mainCode.get())
-                .map(Extension::getExtension)
-                .orElse(Collections.emptyList());
-
-            if (ACTIVE_CLINICAL_STATUS.equals(allergyIntoleranceClinicalStatus.toCode())) {
-                builder.mainCodeSystem(SNOMED_SYSTEM_CODE);
-            } else {
-                builder.nullFlavor(true);
-            }
-
-            Optional<String> code = extension.stream()
+    private static Optional<String> getAllergyMainCode(Coding snomedCodeCoding) {
+        return retrieveDescriptionExtension(snomedCodeCoding)
+            .flatMap(extension -> extension.getExtension().stream()
                 .filter(descriptionExt -> DESCRIPTION_ID.equals(descriptionExt.getUrl()))
-                .map(description -> description.getValue().toString())
                 .findFirst()
-                .or(() -> Optional.ofNullable(mainCode.get().getCode()));
-            code.ifPresent(builder::mainCode);
-
-            Optional<String> displayName = Optional.ofNullable(mainCode.get().getDisplay());
-            displayName.ifPresent(builder::mainDisplayName);
-
-            if (codeableConcept.hasText()) {
-                builder.mainOriginalText(codeableConcept.getText());
-            } else {
-                var originalText = findOriginalTextForAllergy(codeableConcept, mainCode, allergyIntoleranceClinicalStatus);
-                originalText.ifPresent(builder::mainOriginalText);
-            }
-        }
-        return TemplateUtils.fillTemplate(CODEABLE_CONCEPT_CD_TEMPLATE, builder.build());
+                .map(description -> description.getValue().toString()))
+            .or(() -> Optional.ofNullable(snomedCodeCoding.getCode()));
     }
 
     public String mapCodeableConceptToCdForTransformedActualProblemHeader(CodeableConcept codeableConcept) {
@@ -343,7 +330,7 @@ public class CodeableConceptCdMapper {
                 return Optional.ofNullable(codeableConcept.getText());
             } else {
                 if (coding.get().hasDisplay()) {
-                    return Optional.ofNullable(coding.get().getDisplay());
+                    return getCodingDisplayName(coding.get());
                 } else {
                     var extension = retrieveDescriptionExtension(coding.get());
                     return extension.stream()
@@ -362,50 +349,67 @@ public class CodeableConceptCdMapper {
         Optional<Coding> coding,
         AllergyIntolerance.AllergyIntoleranceClinicalStatus allergyIntoleranceClinicalStatus
     ) {
+        if (coding.isEmpty()) {
+            return Optional.empty();
+        }
+
         if (!allergyIntoleranceClinicalStatus.toCode().isEmpty()) {
             if (RESOLVED_CLINICAL_STATUS.equals(allergyIntoleranceClinicalStatus.toCode())) {
-                if (coding.isPresent()) {
-                    if (codeableConcept.hasText()) {
-                        return Optional.ofNullable(codeableConcept.getText());
-                    } else {
-                        var extension = retrieveDescriptionExtension(coding.get());
-                        if (extension.isPresent()) {
-                            Optional<String> originalText = extension
-                                .get()
-                                .getExtension().stream()
-                                .filter(displayExtension -> DESCRIPTION_DISPLAY.equals(displayExtension.getUrl()))
-                                .map(extension1 -> extension1.getValue().toString())
-                                .findFirst();
-
-                            if (originalText.isPresent()) {
-                                return originalText;
-                            } else if (coding.get().hasDisplay()) {
-                                return Optional.ofNullable(coding.get().getDisplay());
-                            }
-                        } else if (coding.get().hasDisplay()) {
-                            return Optional.ofNullable(coding.get().getDisplay());
-                        }
-                    }
-                }
-            } else if (ACTIVE_CLINICAL_STATUS.equals(allergyIntoleranceClinicalStatus.toCode())) {
-                Optional<Extension> extension = retrieveDescriptionExtension(coding.get());
-                if (extension.isPresent()) {
-                    Optional<String> originalText = extension
-                        .get()
-                        .getExtension().stream()
-                        .filter(displayExtension -> DESCRIPTION_DISPLAY.equals(displayExtension.getUrl()))
-                        .map(extension1 -> extension1.getValue().toString())
-                        .findFirst();
-                    if (originalText.isPresent() && StringUtils.isNotBlank(originalText.get())) {
-                        return originalText;
-                    }
-                }
-
-                return Optional.empty();
+                return getOriginalTextForResolvedAllergy(codeableConcept, coding.get());
+            }
+            if (ACTIVE_CLINICAL_STATUS.equals(allergyIntoleranceClinicalStatus.toCode())) {
+                return getOriginalTextForActiveAllergy(coding.get());
             }
         }
 
         return CodeableConceptMappingUtils.extractTextOrCoding(codeableConcept);
+    }
+
+    private Optional<String> getOriginalTextForActiveAllergy(Coding coding) {
+        Optional<Extension> extension = retrieveDescriptionExtension(coding);
+
+        if (extension.isPresent()) {
+            Optional<String> originalText = extension
+                .get()
+                .getExtension().stream()
+                .filter(displayExtension -> DESCRIPTION_DISPLAY.equals(displayExtension.getUrl()))
+                .map(extension1 -> extension1.getValue().toString())
+                .findFirst();
+            if (originalText.isPresent()) {
+                return originalText;
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<String> getOriginalTextForResolvedAllergy(CodeableConcept codeableConcept, Coding coding) {
+
+        if (codeableConcept.hasText()) {
+            return Optional.ofNullable(codeableConcept.getText());
+        }
+
+        var extension = retrieveDescriptionExtension(coding);
+        if (extension.isEmpty()) {
+            return coding.hasDisplay()
+                ? Optional.ofNullable(coding.getDisplay())
+                : Optional.empty();
+        }
+
+        Optional<String> originalText = extension
+            .get()
+            .getExtension().stream()
+            .filter(displayExtension -> DESCRIPTION_DISPLAY.equals(displayExtension.getUrl()))
+            .map(extension1 -> extension1.getValue().toString())
+            .findFirst();
+
+        if (originalText.isPresent()) {
+            return originalText;
+        } else if (coding.hasDisplay()) {
+            return Optional.ofNullable(coding.getDisplay());
+        }
+
+        return Optional.empty();
     }
 
     private Optional<String> findDisplayText(Coding coding) {
@@ -420,7 +424,7 @@ public class CodeableConceptCdMapper {
         return coding.hasSystem() && coding.getSystem().equals(CARE_CONNECT_PRESCRIBING_AGENCY_SYSTEM);
     }
 
-    private Optional<Extension> retrieveDescriptionExtension(Coding coding) {
+    private static Optional<Extension> retrieveDescriptionExtension(Coding coding) {
         return coding
             .getExtension()
             .stream()
@@ -435,7 +439,6 @@ public class CodeableConceptCdMapper {
     }
 
     public String mapToNullFlavorCodeableConcept(CodeableConcept codeableConcept) {
-
         var builder = CodeableConceptCdTemplateParameters.builder().nullFlavor(true);
         var mainCode = getSnomedCodeCoding(codeableConcept);
 
@@ -453,15 +456,6 @@ public class CodeableConceptCdMapper {
 
         var originalText = findOriginalTextForAllergy(codeableConcept, mainCode, allergyIntoleranceClinicalStatus);
         originalText.ifPresent(builder::mainOriginalText);
-        return TemplateUtils.fillTemplate(CODEABLE_CONCEPT_CD_TEMPLATE, builder.build());
-    }
-
-    private String buildNullFlavourCodeableConceptCd(CodeableConcept codeableConcept, Optional<Coding> snomedCode) {
-        var builder = CodeableConceptCdTemplateParameters.builder();
-        builder.nullFlavor(true);
-        var originalText = findOriginalText(codeableConcept, snomedCode);
-        originalText.ifPresent(builder::mainOriginalText);
-
         return TemplateUtils.fillTemplate(CODEABLE_CONCEPT_CD_TEMPLATE, builder.build());
     }
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
@@ -360,21 +360,13 @@ public class CodeableConceptCdMapper {
     }
 
     private Optional<String> getOriginalTextForActiveAllergy(Coding coding) {
-        Optional<Extension> extension = retrieveDescriptionExtension(coding);
-
-        if (extension.isPresent()) {
-            Optional<String> originalText = extension
-                .get()
+        return retrieveDescriptionExtension(coding)
+            .flatMap(value -> value
                 .getExtension().stream()
                 .filter(displayExtension -> DESCRIPTION_DISPLAY.equals(displayExtension.getUrl()))
                 .map(extension1 -> extension1.getValue().toString())
-                .findFirst();
-            if (originalText.isPresent()) {
-                return originalText;
-            }
-        }
-
-        return Optional.empty();
+                .findFirst()
+            );
     }
 
     private Optional<String> findDisplayText(Coding coding) {

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
@@ -127,6 +127,46 @@ public class CodeableConceptCdMapperTest {
         assertThat(outputMessageXml).isEqualToIgnoringWhitespace(expectedOutputXml);
     }
 
+
+    @Test
+    void When_mapToNullFlavorCodeableConceptForAllergyWithoutSnomedCode_ExpectOriginalTextIsNotPresent() {
+        var inputJson = """
+            {
+                "resourceType": "AllergyIntolerance",
+                "id": "0C1232CF-D34B-4C16-A5F4-0F6461C51A41",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-AllergyIntolerance-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://EMISWeb/A82038",
+                        "value": "55D2363D57A248F49A745B2E03F5E93D0C1232CFD34B4C16A5F40F6461C51A41"
+                    }
+                ],
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://read.info/readv2",
+                            "code": "TJ00800",
+                            "display": "Adverse reaction to pivampicillin rt"
+                        }
+                    ],
+                    "text": "Adverse reaction to pivampicillin"
+                }
+            }""";
+        var expectedOutputXML = """
+            <code nullFlavor="UNK">
+            </code>
+            """;
+        var codeableConcept = fhirParseService.parseResource(inputJson, AllergyIntolerance.class).getCode();
+
+        var outputXml = codeableConceptCdMapper.mapToNullFlavorCodeableConceptForAllergy(codeableConcept, AllergyIntolerance.AllergyIntoleranceClinicalStatus.ACTIVE);
+
+        assertThat(outputXml).isEqualToIgnoringWhitespace(expectedOutputXML);
+    }
+
     @ParameterizedTest
     @MethodSource("getTestArgumentsActualProblem")
     public void When_MappingStubbedCodeableConceptForActualProblemHeader_Expect_HL7CdObjectXml(String inputJson, String outputXml)
@@ -271,4 +311,5 @@ public class CodeableConceptCdMapperTest {
 
         assertThat(outputString).isEqualToIgnoringWhitespace(expectedOutput);
     }
+
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
@@ -127,9 +127,8 @@ public class CodeableConceptCdMapperTest {
         assertThat(outputMessageXml).isEqualToIgnoringWhitespace(expectedOutputXml);
     }
 
-
     @Test
-    void When_mapToNullFlavorCodeableConceptForAllergyWithoutSnomedCode_ExpectOriginalTextIsNotPresent() {
+    void When_MapToNullFlavorCodeableConceptForAllergyWithoutSnomedCode_Expect_OriginalTextIsNotPresent() {
         var inputJson = """
             {
                 "resourceType": "AllergyIntolerance",
@@ -162,9 +161,57 @@ public class CodeableConceptCdMapperTest {
             """;
         var codeableConcept = fhirParseService.parseResource(inputJson, AllergyIntolerance.class).getCode();
 
-        var outputXml = codeableConceptCdMapper.mapToNullFlavorCodeableConceptForAllergy(codeableConcept, AllergyIntolerance.AllergyIntoleranceClinicalStatus.ACTIVE);
+        var outputXml = codeableConceptCdMapper.mapToNullFlavorCodeableConceptForAllergy(
+            codeableConcept,
+            AllergyIntolerance.AllergyIntoleranceClinicalStatus.ACTIVE
+        );
 
         assertThat(outputXml).isEqualToIgnoringWhitespace(expectedOutputXML);
+    }
+
+    @Test
+    void When_MappingStubbedCodeableConceptAsInactiveAllergy_Expect_NullFlavourCodeableConceptWithOriginalTextAsDisplayName() {
+        var inputJson = """
+            {
+                "resourceType": "AllergyIntolerance",
+                "id": "0C1232CF-D34B-4C16-A5F4-0F6461C51A41",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-AllergyIntolerance-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://EMISWeb/A82038",
+                        "value": "55D2363D57A248F49A745B2E03F5E93D0C1232CFD34B4C16A5F40F6461C51A41"
+                    }
+                ],
+                "clinicalStatus": "inactive",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "292971006",
+                            "display": "Pivampicillin adverse reaction pt"
+                        }
+                    ]
+                }
+            }""";
+
+        var expectedOutputXML = """
+            <code nullFlavor="UNK">
+                <originalText>Pivampicillin adverse reaction pt</originalText>
+            </code>
+            """;
+        var codeableConcept = fhirParseService.parseResource(inputJson, AllergyIntolerance.class).getCode();
+
+        var outputXml = codeableConceptCdMapper.mapToNullFlavorCodeableConceptForAllergy(
+            codeableConcept,
+            AllergyIntolerance.AllergyIntoleranceClinicalStatus.INACTIVE
+        );
+
+        assertThat(outputXml).isEqualToIgnoringWhitespace(expectedOutputXML);
+
     }
 
     @ParameterizedTest

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
@@ -358,5 +358,4 @@ public class CodeableConceptCdMapperTest {
 
         assertThat(outputString).isEqualToIgnoringWhitespace(expectedOutput);
     }
-
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
@@ -169,51 +169,6 @@ public class CodeableConceptCdMapperTest {
         assertThat(outputXml).isEqualToIgnoringWhitespace(expectedOutputXML);
     }
 
-    @Test
-    void When_MappingStubbedCodeableConceptAsInactiveAllergy_Expect_NullFlavourCodeableConceptWithOriginalTextAsDisplayName() {
-        var inputJson = """
-            {
-                "resourceType": "AllergyIntolerance",
-                "id": "0C1232CF-D34B-4C16-A5F4-0F6461C51A41",
-                "meta": {
-                    "profile": [
-                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-AllergyIntolerance-1"
-                    ]
-                },
-                "identifier": [
-                    {
-                        "system": "https://EMISWeb/A82038",
-                        "value": "55D2363D57A248F49A745B2E03F5E93D0C1232CFD34B4C16A5F40F6461C51A41"
-                    }
-                ],
-                "clinicalStatus": "inactive",
-                "code": {
-                    "coding": [
-                        {
-                            "system": "http://snomed.info/sct",
-                            "code": "292971006",
-                            "display": "Pivampicillin adverse reaction pt"
-                        }
-                    ]
-                }
-            }""";
-
-        var expectedOutputXML = """
-            <code nullFlavor="UNK">
-                <originalText>Pivampicillin adverse reaction pt</originalText>
-            </code>
-            """;
-        var codeableConcept = fhirParseService.parseResource(inputJson, AllergyIntolerance.class).getCode();
-
-        var outputXml = codeableConceptCdMapper.mapToNullFlavorCodeableConceptForAllergy(
-            codeableConcept,
-            AllergyIntolerance.AllergyIntoleranceClinicalStatus.INACTIVE
-        );
-
-        assertThat(outputXml).isEqualToIgnoringWhitespace(expectedOutputXML);
-
-    }
-
     @ParameterizedTest
     @MethodSource("getTestArgumentsActualProblem")
     public void When_MappingStubbedCodeableConceptForActualProblemHeader_Expect_HL7CdObjectXml(String inputJson, String outputXml)

--- a/service/src/test/resources/ehr/mapper/codeableconcept/allergyActive/allergy_with_snomed_and_non_snomed_codes_in_coding_no_text.json
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/allergyActive/allergy_with_snomed_and_non_snomed_codes_in_coding_no_text.json
@@ -1,0 +1,49 @@
+{
+    "resourceType": "AllergyIntolerance",
+    "id": "0C1232CF-D34B-4C16-A5F4-0F6461C51A41",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-AllergyIntolerance-1"
+        ]
+    },
+    "identifier": [
+        {
+            "system": "https://EMISWeb/A82038",
+            "value": "55D2363D57A248F49A745B2E03F5E93D0C1232CFD34B4C16A5F40F6461C51A41"
+        }
+    ],
+    "clinicalStatus": "resolved",
+    "verificationStatus": "unconfirmed",
+    "category": [ "medication" ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "292971006",
+                "display": "Pivampicillin adverse reaction pt"
+            },
+            {
+                "system": "http://read.info/readv2",
+                "code": "TJ00800",
+                "display": "Adverse reaction to pivampicillin pt"
+            },
+            {
+                "system": "http://read.info/ctv3",
+                "code": "TJ00800-1",
+                "display": "Adverse reaction to pivampicillin"
+            }
+        ]
+    },
+    "patient": {
+        "reference": "Patient/55D2363D-57A2-48F4-9A74-5B2E03F5E93D"
+    },
+    "assertedDate": "2019-01-28T13:43:36.107+00:00",
+    "recorder": {
+        "reference": "Practitioner/2DB481A3-306A-4133-9491-1558161D6A2B"
+    },
+    "note": [
+        {
+            "text": "allergy with no date recorded"
+        }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/codeableconcept/allergyActive/allergy_with_snomed_and_non_snomed_codes_in_coding_no_text.xml
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/allergyActive/allergy_with_snomed_and_non_snomed_codes_in_coding_no_text.xml
@@ -1,0 +1,4 @@
+<code code="292971006" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Pivampicillin adverse reaction pt">
+    <translation code="TJ00800" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Adverse reaction to pivampicillin pt" />
+    <translation code="TJ00800-1" codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="Adverse reaction to pivampicillin" />
+</code>

--- a/service/src/test/resources/ehr/mapper/codeableconcept/allergyActive/allergy_with_snomed_and_non_snomed_codes_in_coding_with_text.json
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/allergyActive/allergy_with_snomed_and_non_snomed_codes_in_coding_with_text.json
@@ -1,0 +1,50 @@
+{
+    "resourceType": "AllergyIntolerance",
+    "id": "0C1232CF-D34B-4C16-A5F4-0F6461C51A41",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-AllergyIntolerance-1"
+        ]
+    },
+    "identifier": [
+        {
+            "system": "https://EMISWeb/A82038",
+            "value": "55D2363D57A248F49A745B2E03F5E93D0C1232CFD34B4C16A5F40F6461C51A41"
+        }
+    ],
+    "clinicalStatus": "resolved",
+    "verificationStatus": "unconfirmed",
+    "category": [ "medication" ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "292971006",
+                "display": "Pivampicillin adverse reaction pt"
+            },
+            {
+                "system": "http://read.info/readv2",
+                "code": "TJ00800",
+                "display": "Adverse reaction to pivampicillin pt"
+            },
+            {
+                "system": "http://read.info/ctv3",
+                "code": "TJ00800-1",
+                "display": "Adverse reaction to pivampicillin"
+            }
+        ],
+        "text": "Pivampicillin adverse reaction (rt)"
+    },
+    "patient": {
+        "reference": "Patient/55D2363D-57A2-48F4-9A74-5B2E03F5E93D"
+    },
+    "assertedDate": "2019-01-28T13:43:36.107+00:00",
+    "recorder": {
+        "reference": "Practitioner/2DB481A3-306A-4133-9491-1558161D6A2B"
+    },
+    "note": [
+        {
+            "text": "allergy with no date recorded"
+        }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/codeableconcept/allergyActive/allergy_with_snomed_and_non_snomed_codes_in_coding_with_text.xml
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/allergyActive/allergy_with_snomed_and_non_snomed_codes_in_coding_with_text.xml
@@ -1,0 +1,5 @@
+<code code="292971006" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Pivampicillin adverse reaction pt">
+    <translation code="TJ00800" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Adverse reaction to pivampicillin pt" />
+    <translation code="TJ00800-1" codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="Adverse reaction to pivampicillin" />
+    <originalText>Pivampicillin adverse reaction (rt)</originalText>
+</code>

--- a/service/src/test/resources/ehr/mapper/codeableconcept/allergyResolved/allergy_with_snomed_and_non_snomed_codes_in_coding_no_text.json
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/allergyResolved/allergy_with_snomed_and_non_snomed_codes_in_coding_no_text.json
@@ -1,0 +1,49 @@
+{
+    "resourceType": "AllergyIntolerance",
+    "id": "0C1232CF-D34B-4C16-A5F4-0F6461C51A41",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-AllergyIntolerance-1"
+        ]
+    },
+    "identifier": [
+        {
+            "system": "https://EMISWeb/A82038",
+            "value": "55D2363D57A248F49A745B2E03F5E93D0C1232CFD34B4C16A5F40F6461C51A41"
+        }
+    ],
+    "clinicalStatus": "resolved",
+    "verificationStatus": "unconfirmed",
+    "category": [ "medication" ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "292971006",
+                "display": "Pivampicillin adverse reaction pt"
+            },
+            {
+                "system": "http://read.info/readv2",
+                "code": "TJ00800",
+                "display": "Adverse reaction to pivampicillin rt"
+            },
+            {
+                "system": "http://read.info/ctv",
+                "code": "TJ00800-1",
+                "display": "Adverse reaction to pivampicillin"
+            }
+        ]
+    },
+    "patient": {
+        "reference": "Patient/55D2363D-57A2-48F4-9A74-5B2E03F5E93D"
+    },
+    "assertedDate": "2019-01-28T13:43:36.107+00:00",
+    "recorder": {
+        "reference": "Practitioner/2DB481A3-306A-4133-9491-1558161D6A2B"
+    },
+    "note": [
+        {
+            "text": "allergy with no date recorded"
+        }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/codeableconcept/allergyResolved/allergy_with_snomed_and_non_snomed_codes_in_coding_no_text.xml
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/allergyResolved/allergy_with_snomed_and_non_snomed_codes_in_coding_no_text.xml
@@ -1,0 +1,3 @@
+<code nullFlavor="UNK">
+    <originalText>Pivampicillin adverse reaction pt</originalText>
+</code>

--- a/service/src/test/resources/ehr/mapper/codeableconcept/allergyResolved/allergy_with_snomed_and_non_snomed_codes_in_coding_with_text.json
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/allergyResolved/allergy_with_snomed_and_non_snomed_codes_in_coding_with_text.json
@@ -1,0 +1,50 @@
+{
+    "resourceType": "AllergyIntolerance",
+    "id": "0C1232CF-D34B-4C16-A5F4-0F6461C51A41",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-AllergyIntolerance-1"
+        ]
+    },
+    "identifier": [
+        {
+            "system": "https://EMISWeb/A82038",
+            "value": "55D2363D57A248F49A745B2E03F5E93D0C1232CFD34B4C16A5F40F6461C51A41"
+        }
+    ],
+    "clinicalStatus": "resolved",
+    "verificationStatus": "unconfirmed",
+    "category": [ "medication" ],
+    "code": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "292971006",
+                "display": "Pivampicillin adverse reaction pt"
+            },
+            {
+                "system": "http://read.info/readv2",
+                "code": "TJ00800",
+                "display": "Adverse reaction to pivampicillin pt"
+            },
+            {
+                "system": "http://read.info/ctv",
+                "code": "TJ00800-1",
+                "display": "Adverse reaction to pivampicillin (rt)"
+            }
+        ],
+        "text": "Pivampicillin adverse reaction (rt)"
+    },
+    "patient": {
+        "reference": "Patient/55D2363D-57A2-48F4-9A74-5B2E03F5E93D"
+    },
+    "assertedDate": "2019-01-28T13:43:36.107+00:00",
+    "recorder": {
+        "reference": "Practitioner/2DB481A3-306A-4133-9491-1558161D6A2B"
+    },
+    "note": [
+        {
+            "text": "allergy with no date recorded"
+        }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/codeableconcept/allergyResolved/allergy_with_snomed_and_non_snomed_codes_in_coding_with_text.xml
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/allergyResolved/allergy_with_snomed_and_non_snomed_codes_in_coding_with_text.xml
@@ -1,0 +1,3 @@
+<code nullFlavor="UNK">
+    <originalText>Pivampicillin adverse reaction (rt)</originalText>
+</code>


### PR DESCRIPTION
## What

* Add test files for `active` and `resolved` allergies where both snomed and non-snomed codes are provided, with and without text field provided.
* Update `mapCodeableConceptToCdForAllergy` to provide translations in cases where the code is no an `UNK` null flavour.

## Why

The GP2GP Sending Adaptor does not currently preserve non-SNOMEDCT codes when mapping CodeableConcepts.
The GP2GP Request Adaptor does preserve this codes when a SNOMEDCT code is also present in the coding block.
It is necessary as part of FRA that these are preserved when transferring a patient out of NME system.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes