### PR TITLE
NIAD-3152: Send over ProcedureRequest.meta.security NOPAT field to incumbent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* GP2GP Adaptor now populates the PlanStatement / confidentialityCode field 
+when the ProcedureRequest.meta.security field contains NOPAT and the message type is RCMR_IN030000UK07
+
 ## [2.2.2] - 2025-02-07
 
 ### Fixed

--- a/service/src/main/resources/templates/ehr_plan_statement_template.mustache
+++ b/service/src/main/resources/templates/ehr_plan_statement_template.mustache
@@ -12,6 +12,9 @@
             <center {{{effectiveTime}}}/>
         </effectiveTime>
         {{#availabilityTime}}<availabilityTime value="{{.}}"/>{{/availabilityTime}}
+        {{#confidentialityCode}}
+            {{{confidentialityCode}}}
+        {{/confidentialityCode}}
         {{#author}}
         <author typeCode="AUT" contextControlCode="OP">
             {{#authorTime}}<time value="{{.}}" />{{/authorTime}}

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DiaryPlanStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/DiaryPlanStatementMapperTest.java
@@ -5,8 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
-
-import java.io.IOException;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -61,7 +59,8 @@ public class DiaryPlanStatementMapperTest {
 
     public static final String CONFIDENTIALITY_CODE = "<confidentialityCode code=\"NOPAT\" "
                                                       + "codeSystem=\"2.16.840.1.113883.4.642.3.47\" "
-                                                      + "displayName=\"no disclosure to patient, family or caregivers without attending provider's authorization\" />";
+                                                      + "displayName=\"no disclosure to patient, family or "
+                                                      + "caregivers without attending provider's authorization\" />";
 
     @Mock
     private RandomIdGeneratorService randomIdGeneratorService;

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
@@ -164,7 +164,7 @@ public class EhrExtractMapperComponentTest {
                 codeableConceptCdMapper, new ParticipantMapper()),
             new ConditionLinkSetMapper(
                 messageContext, randomIdGeneratorService, codeableConceptCdMapper, participantMapper, confidentialityService),
-            new DiaryPlanStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
+            new DiaryPlanStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService),
             documentReferenceToNarrativeStatementMapper,
             new ImmunizationObservationStatementMapper(
                 messageContext,

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
@@ -152,7 +152,7 @@ public class EncounterComponentsMapperTest {
             confidentialityService
         );
         DiaryPlanStatementMapper diaryPlanStatementMapper
-            = new DiaryPlanStatementMapper(messageContext, codeableConceptCdMapper, participantMapper);
+            = new DiaryPlanStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService);
         DocumentReferenceToNarrativeStatementMapper documentReferenceToNarrativeStatementMapper
             = new DocumentReferenceToNarrativeStatementMapper(
                 messageContext, new SupportedContentTypes(), participantMapper, confidentialityService);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
@@ -184,7 +184,7 @@ public class EhrExtractUATTest {
                 codeableConceptCdMapper, new ParticipantMapper()),
             new ConditionLinkSetMapper(
                 messageContext, randomIdGeneratorService, codeableConceptCdMapper, participantMapper, confidentialityService),
-            new DiaryPlanStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
+            new DiaryPlanStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService),
             documentReferenceToNarrativeStatementMapper,
             new ImmunizationObservationStatementMapper(
                 messageContext,

--- a/service/src/test/resources/ehr/mapper/procedurerequest/procedure-request-resource-1.json
+++ b/service/src/test/resources/ehr/mapper/procedurerequest/procedure-request-resource-1.json
@@ -1,6 +1,16 @@
 {
     "resourceType": "ProcedureRequest",
     "id": "1B1C6F50-D8BE-4480-83D6-EF25AC5F1836",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Immunization-1"
+        ],
+        "security": [{
+            "system":"http://hl7.org/fhir/v3/ActCode",
+            "code":"NOPAT",
+            "display":"no disclosure to patient, family or caregivers without attending provider's authorization"
+        }]
+    },
     "status": "active",
     "intent": "plan",
     "code": {


### PR DESCRIPTION
## What

Send over ProcedureRequest.meta.security NOPAT field to incumbent

## Why

This change is part of a broader scope of work aimed at ensuring the GP2GP sending adapter complies with Redactions requirements

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
