### PR TITLE
NIAD-3304: Adaptor not preserving legacy read codes on export

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
@@ -328,7 +328,7 @@ public class CodeableConceptCdMapper {
     private Optional<String> findOriginalText(
         CodeableConcept codeableConcept,
         Optional<Coding> coding,
-        Function<Coding, List<Extension>> function) {
+        Function<Coding, List<Extension>> getOriginalTextFromDescriptionExtension) {
 
         if (coding.isPresent()) {
             if (codeableConcept.hasText()) {
@@ -337,7 +337,7 @@ public class CodeableConceptCdMapper {
                 if (coding.get().hasDisplay()) {
                     return getCodingDisplayName(coding.get());
                 } else {
-                    var extension = function.apply(coding.get());
+                    var extension = getOriginalTextFromDescriptionExtension.apply(coding.get());
                     return extension.stream()
                         .filter(displayExtension -> DESCRIPTION_DISPLAY.equals(displayExtension.getUrl()))
                         .map(extension1 -> extension1.getValue().toString())

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
@@ -575,6 +575,36 @@ public class CodeableConceptCdMapperTest {
 
             assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
         }
+
+        @Test
+        void When_WithSnomedCodingNoTextNoDisplayWithNonDescriptionExtension_Expect_SnomedCdXmlWithoutOriginalText() {
+            var inputJson = """
+                {
+                    "resourceType": "Observation",
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "852471000000107",
+                                "extension": [
+                                    {
+                                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-some-otherUrl"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }""";
+
+            var expectedOutput = """
+                <code nullFlavor="UNK">
+                </code>""";
+            var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+
+            var outputMessage = codeableConceptCdMapper.mapToNullFlavorCodeableConcept(codeableConcept);
+
+            assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+        }
     }
 
     @ParameterizedTest

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
@@ -442,7 +442,7 @@ public class CodeableConceptCdMapperTest {
                                          "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
                                          "extension": [
                                              {
-                                                 "url": "descriptionId",
+                                                 "url": "descriptioÍnId",
                                                  "valueId": "12345789"
                                              }
                                          ]
@@ -520,7 +520,43 @@ public class CodeableConceptCdMapperTest {
                                         "extension": [
                                             {
                                                 "url": "descriptionId",
-                                                "valueId": "12345789"
+                                                "valueString": "123456789"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }""";
+
+            var expectedOutput = """
+                <code nullFlavor="UNK">
+                </code>""";
+            var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+
+            var outputMessage = codeableConceptCdMapper.mapToNullFlavorCodeableConcept(codeableConcept);
+
+            assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+        }
+
+        @Test
+        void When_WithSnomedCodingNoTextNoDisplayWithDescriptionExtensionWithDisplayExtension_Expect_SnomedCdXmlWithoutOriginalText() {
+            var inputJson = """
+                {
+                    "resourceType": "Observation",
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "852471000000107",
+                                "extension": [
+                                    {
+                                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                        "extension": [
+                                            {
+                                                "url": "descriptionDisplay",
+                                                "valueString": "Prothrombin time (observed)"
                                             }
                                         ]
                                     }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
@@ -10,6 +10,7 @@ import org.hl7.fhir.dstu3.model.Condition;
 import org.hl7.fhir.dstu3.model.Medication;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -26,7 +27,6 @@ public class CodeableConceptCdMapperTest {
     private static final String TEST_FILE_DIRECTORY_ACTUAL_PROBLEM = "/ehr/mapper/codeableconcept/actualProblem/";
     private static final String TEST_FILE_DIRECTORY_ALLERGY_RESOLVED = "/ehr/mapper/codeableconcept/allergyResolved/";
     private static final String TEST_FILE_DIRECTORY_ALLERGY_ACTIVE = "/ehr/mapper/codeableconcept/allergyActive/";
-    //private static final String TEST_FILE_DIRECTORY_BLOOD_PRESSURE = "/ehr/mapper/codeableconcept/bloodPressure/";
     private static final String TEST_FILE_DIRECTORY_MEDICATION = "/ehr/mapper/codeableconcept/medication/";
 
     private static final String TEST_FILE_TOPIC_RELATED_CONDITION = TEST_FILE_DIRECTORY
@@ -232,148 +232,314 @@ public class CodeableConceptCdMapperTest {
             .isEqualToIgnoringWhitespace(expectedOutput);
     }
 
-    @Test
-    void When_MappingStubbedCodeableConceptWithoutCoding_Expect_NullFlavorCdXmlWithoutOriginalText() {
-        var inputJson = """
-            {
-                "resourceType": "Observation"
-            }""";
-        var expectedOutput = """
+    @Nested
+    class WhenMappingStubbedCodeableConceptForBloodPressure {
+        @Test
+        void When_WithoutCoding_Expect_NullFlavorCdXmlWithoutOriginalText() {
+            var inputJson = """
+                {
+                    "resourceType": "Observation"
+                }""";
+            var expectedOutput = """
             <code nullFlavor="UNK">
             </code>""";
-        var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+            var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
 
-        var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
+            var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
 
-        assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
-    }
+            assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+        }
 
-    @Test
-    void When_MappingStubbedCodeableConceptWithNonSnomedCodingWithDisplay_Expect_NullFlavorCdXmlWithOriginalText() {
-        var inputJson = """
-            {
-                "resourceType": "Observation",
-                "code": {
-                      "coding": [
-                          {
-                              "display": "Prothrombin time"
-                          }
-                      ]
-                  }
-            }""";
-        var expectedOutput = """
-            <code nullFlavor="UNK">
-                <originalText>Prothrombin time</originalText>
-            </code>""";
-        var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+        @Test
+        void When_WithNonSnomedCodingWithDisplay_Expect_NullFlavorCdXmlWithOriginalText() {
+            var inputJson = """
+                {
+                     "resourceType": "Observation",
+                     "code": {
+                         "coding": [
+                             {
+                                 "display": "Prothrombin time"
+                             }
+                         ]
+                     }
+                }""";
 
-        var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
+            var expectedOutput = """
+                <code nullFlavor="UNK">
+                    <originalText>Prothrombin time</originalText>
+                </code>""";
+            var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
 
-        assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
-    }
+            var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
 
-    @Test
-    void When_MappingStubbedCodeableConceptWithSnomedCodingWithDisplay_Expect_SnomedCdXmlWithOriginalText() {
-        var inputJson = """
-            {
-                "resourceType": "Observation",
-                "code": {
-                      "coding": [
-                          {
-                               "system": "http://snomed.info/sct",
-                               "display": "Prothrombin time",
-                               "code": "852471000000107"
-                           }
-                      ]
-                  }
-            }""";
-        var expectedOutput = """
-            <code code="852471000000107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Prothrombin time">
-                <originalText>Prothrombin time</originalText>
-            </code>""";
-        var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+            assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+        }
 
-        var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
+        @Test
+        void When_WithSnomedCodingWithDisplay_Expect_SnomedCdXmlWithOriginalText() {
+            var inputJson = """
+                {
+                     "resourceType": "Observation",
+                     "code": {
+                         "coding": [
+                             {
+                                 "system": "http://snomed.info/sct",
+                                 "display": "Prothrombin time",
+                                 "code": "852471000000107"
+                             }
+                         ]
+                     }
+                }""";
+            var expectedOutput = """
+                <code code="852471000000107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Prothrombin time">
+                    <originalText>Prothrombin time</originalText>
+                </code>""";
+            var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
 
-        assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
-    }
+            var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
 
-    @Test
-    void When_MappingStubbedCodeableConceptWithSnomedCodingWithoutCode_Expect_SnomedCdXmlWithOriginalTextFromText() {
-        var inputJson = """
-            {
-                "resourceType": "Observation",
-                "code": {
-                      "coding": [
-                          {
-                               "system": "http://snomed.info/sct",
-                               "display": "Prothrombin time",
-                               "code": "852471000000107"
-                          }
-                      ],
-                      "text": "Prothrombin time observed"
-                  }
-            }""";
-        var expectedOutput = """
-            <code code="852471000000107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Prothrombin time">
-                <originalText>Prothrombin time observed</originalText>
-            </code>""";
-        var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+            assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+        }
 
-        var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
+        @Test
+        void When_WithSnomedCodingWithoutCode_Expect_SnomedCdXmlWithOriginalTextFromText() {
+            var inputJson = """
+                {
+                     "resourceType": "Observation",
+                     "code": {
+                         "coding": [
+                             {
+                                 "system": "http://snomed.info/sct",
+                                 "display": "Prothrombin time",
+                                 "code": "852471000000107"
+                             }
+                         ],
+                         "text": "Prothrombin time observed"
+                     }
+                }""";
+            var expectedOutput = """
+                <code code="852471000000107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Prothrombin time">
+                    <originalText>Prothrombin time observed</originalText>
+                </code>""";
+            var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
 
-        assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
-    }
+            var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
 
-    @Test
-    void When_MappingStubbedCodeableConceptWithSnomedCodingWithPartialExtensionWithoutCode_Expect_SnomedCdXmlWithOriginalTextFromExtension() {
-        var inputJson = """
-            {
-                "resourceType": "Observation",
-                "code": {
-                      "coding": [
-                          {
-                               "system": "http://snomed.info/sct",
-                               "code": "852471000000107",
-                               "extension": [
+            assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+        }
+
+        @Test
+        void When_WithSnomedCodingWithoutDisplayWithDescriptionExtensionWithoutDisplay_Expect_SnomedCdXml() {
+            var inputJson = """
+                {
+                    "resourceType": "Observation",
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://snomed.info/sct",
+                                "code": "852471000000107",
+                                "extension": [
                                     {
                                         "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
                                         "extension": [
-                                          {
-                                              "url": "descriptionDisplay",
-                                              "valueId": "Prothrombin time (observed)"
-                                          }
+                                            {
+                                                "url": "descriptionId",
+                                                "valueId": "12345789"
+                                            }
                                         ]
                                     }
                                 ]
-                          }
-                      ]
-                  }
-            }""";
-        var expectedOutput = """
-            <code code="852471000000107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Prothrombin time">
-                <originalText>Prothrombin time (observed)</originalText>
-            </code>""";
-        var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+                            }
+                        ]
+                    }
+                }""";
+            var expectedOutput = """
+                <code code="852471000000107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="">
+                </code>""";
+            var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
 
-        var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
+            var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
 
-        assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+            assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+        }
+
+        @Test
+        void When_WithSnomedCodingNoDisplayWithDescriptionExtensionWithDisplay_Expect_SnomedCdXmlWithOriginalTextFromExtensionDisplay() {
+            var inputJson = """
+                {
+                     "resourceType": "Observation",
+                     "code": {
+                         "coding": [
+                             {
+                                 "system": "http://snomed.info/sct",
+                                 "code": "852471000000107",
+                                 "extension": [
+                                     {
+                                         "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                         "extension": [
+                                             {
+                                                 "url": "descriptionDisplay",
+                                                 "valueString": "Prothrombin time (observed)"
+                                             }
+                                         ]
+                                     }
+                                 ]
+                             }
+                         ]
+                     }
+                }""";
+            var expectedOutput = """
+                <code code="852471000000107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="">
+                    <originalText>Prothrombin time (observed)</originalText>
+                </code>""";
+            var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+
+            var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
+
+            assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+        }
+
+        @Test
+        void When_WithoutSnomedCodingWithText_Expect_NullFlavorUnkCDWithOriginalTextFromText() {
+            var inputJson = """
+                {
+                     "resourceType": "Observation",
+                     "code": {
+                         "coding": [
+                             {
+                                 "system": "http://read.info/readv2",
+                                 "code": "42Q5.00",
+                                 "display": "Prothrombin time"
+                             }
+                         ],
+                         "text": "Prothrombin time (observed)"
+                     }
+                }""";
+            var expectedOutput = """
+                <code nullFlavor="UNK">
+                    <originalText>Prothrombin time (observed)</originalText>
+                </code>""";
+            var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+
+            var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
+
+            assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+        }
+
+        @Test
+        void When_WithNonSnomedCodingWithDescriptionExtensionWithoutDisplay_Expect_SnomedCdXmlWithOriginalTextFromDisplay() {
+            var inputJson = """
+                {
+                     "resourceType": "Observation",
+                     "code": {
+                         "coding": [
+                             {
+                                 "system": "http://read.info/readv2",
+                                 "code": "42Q5.00",
+                                 "display": "Prothrombin time",
+                                 "extension": [
+                                     {
+                                         "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                         "extension": [
+                                             {
+                                                 "url": "descriptionId",
+                                                 "valueId": "12345789"
+                                             }
+                                         ]
+                                     }
+                                 ]
+                             }
+                         ]
+                     }
+                }""";
+            var expectedOutput = """
+                <code nullFlavor="UNK">
+                    <originalText>Prothrombin time</originalText>
+                </code>""";
+            var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+
+            var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
+
+            assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+        }
+
+        @Test
+        void When_WithNonSnomedCodingWithDescriptionExtensionWithDisplayExtension_Expect_SnomedCdXmlWithOriginalTextFromDisplayExtension() {
+            var inputJson = """
+                {
+                     "resourceType": "Observation",
+                     "code": {
+                         "coding": [
+                             {
+                                 "system": "http://read.info/readv2",
+                                 "code": "42Q5.00",
+                                 "display": "Prothrombin time",
+                                 "extension": [
+                                     {
+                                         "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                         "extension": [
+                                             {
+                                                 "url": "descriptionDisplay",
+                                                 "valueString": "Prothrombin time (observed)"
+                                             }
+                                         ]
+                                     }
+                                 ]
+                             }
+                         ]
+                     }
+                }""";
+            var expectedOutput = """
+                <code nullFlavor="UNK">
+                    <originalText>Prothrombin time (observed)</originalText>
+                </code>""";
+            var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+
+            var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
+
+            assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+        }
     }
-//    @ParameterizedTest
-//    @MethodSource("getTestArgumentsBloodPressure")
-//    void When_MappingStubbedCodeableConceptForBloodPressure_Expect_HL7CdObjectXml(String inputJson, String outputXml) {
-//        var allergyCodeableConcept = ResourceTestFileUtils.getFileContent(inputJson);
-//        var expectedOutput = ResourceTestFileUtils.getFileContent(outputXml);
-//        var codeableConcept = fhirParseService.parseResource(allergyCodeableConcept, AllergyIntolerance.class).getCode();
-//
-//        var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForAllergy(codeableConcept,
-//            AllergyIntolerance.AllergyIntoleranceClinicalStatus.ACTIVE);
-//
-//        assertThat(outputMessage)
-//            .describedAs(TestArgumentsLoaderUtil.FAIL_MESSAGE, inputJson, outputXml)
-//            .isEqualToIgnoringWhitespace(expectedOutput);
-//    }
+
+    @Nested
+    class WhenMappingToNullFlavorCodeableConcept {
+
+        @Test
+        void When_WithNonSnomedCodingWithNoDisplayNoTextAndDescriptionExtensionNoDisplayExtension_Expect_SnomedCdXmlWithoutOriginalText() {
+            var inputJson = """
+                {
+                    "resourceType": "Observation",
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://read.info/readv2",
+                                "code": "42Q5.00",
+                                "extension": [
+                                    {
+                                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                        "extension": [
+                                            {
+                                                "url": "descriptionId",
+                                                "valueId": "12345789"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }""";
+
+            var expectedOutput = """
+                <code nullFlavor="UNK">
+                </code>""";
+            var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+
+            var outputMessage = codeableConceptCdMapper.mapToNullFlavorCodeableConcept(codeableConcept);
+
+            assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+        }
+    }
 
     @ParameterizedTest
     @MethodSource("getTestArgumentsForTopicRelatedProblem")

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
@@ -233,7 +233,7 @@ public class CodeableConceptCdMapperTest {
     }
 
     @Test
-    void When_MappingStubbedCodableConceptWithoutCoding_Expect_NullFlavorCdXmlWithoutOriginalText() {
+    void When_MappingStubbedCodeableConceptWithoutCoding_Expect_NullFlavorCdXmlWithoutOriginalText() {
         var inputJson = """
             {
                 "resourceType": "Observation"
@@ -248,6 +248,118 @@ public class CodeableConceptCdMapperTest {
         assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
     }
 
+    @Test
+    void When_MappingStubbedCodeableConceptWithNonSnomedCodingWithDisplay_Expect_NullFlavorCdXmlWithOriginalText() {
+        var inputJson = """
+            {
+                "resourceType": "Observation",
+                "code": {
+                      "coding": [
+                          {
+                              "display": "Prothrombin time"
+                          }
+                      ]
+                  }
+            }""";
+        var expectedOutput = """
+            <code nullFlavor="UNK">
+                <originalText>Prothrombin time</originalText>
+            </code>""";
+        var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+
+        var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
+
+        assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+    }
+
+    @Test
+    void When_MappingStubbedCodeableConceptWithSnomedCodingWithDisplay_Expect_SnomedCdXmlWithOriginalText() {
+        var inputJson = """
+            {
+                "resourceType": "Observation",
+                "code": {
+                      "coding": [
+                          {
+                               "system": "http://snomed.info/sct",
+                               "display": "Prothrombin time",
+                               "code": "852471000000107"
+                           }
+                      ]
+                  }
+            }""";
+        var expectedOutput = """
+            <code code="852471000000107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Prothrombin time">
+                <originalText>Prothrombin time</originalText>
+            </code>""";
+        var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+
+        var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
+
+        assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+    }
+
+    @Test
+    void When_MappingStubbedCodeableConceptWithSnomedCodingWithoutCode_Expect_SnomedCdXmlWithOriginalTextFromText() {
+        var inputJson = """
+            {
+                "resourceType": "Observation",
+                "code": {
+                      "coding": [
+                          {
+                               "system": "http://snomed.info/sct",
+                               "display": "Prothrombin time",
+                               "code": "852471000000107"
+                          }
+                      ],
+                      "text": "Prothrombin time observed"
+                  }
+            }""";
+        var expectedOutput = """
+            <code code="852471000000107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Prothrombin time">
+                <originalText>Prothrombin time observed</originalText>
+            </code>""";
+        var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+
+        var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
+
+        assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+    }
+
+    @Test
+    void When_MappingStubbedCodeableConceptWithSnomedCodingWithPartialExtensionWithoutCode_Expect_SnomedCdXmlWithOriginalTextFromExtension() {
+        var inputJson = """
+            {
+                "resourceType": "Observation",
+                "code": {
+                      "coding": [
+                          {
+                               "system": "http://snomed.info/sct",
+                               "code": "852471000000107",
+                               "extension": [
+                                    {
+                                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                        "extension": [
+                                          {
+                                              "url": "descriptionDisplay",
+                                              "valueId": "Prothrombin time (observed)"
+                                          }
+                                        ]
+                                    }
+                                ]
+                          }
+                      ]
+                  }
+            }""";
+        var expectedOutput = """
+            <code code="852471000000107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Prothrombin time">
+                <originalText>Prothrombin time (observed)</originalText>
+            </code>""";
+        var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+
+        var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
+
+        assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+    }
 //    @ParameterizedTest
 //    @MethodSource("getTestArgumentsBloodPressure")
 //    void When_MappingStubbedCodeableConceptForBloodPressure_Expect_HL7CdObjectXml(String inputJson, String outputXml) {

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
@@ -26,6 +26,7 @@ public class CodeableConceptCdMapperTest {
     private static final String TEST_FILE_DIRECTORY_ACTUAL_PROBLEM = "/ehr/mapper/codeableconcept/actualProblem/";
     private static final String TEST_FILE_DIRECTORY_ALLERGY_RESOLVED = "/ehr/mapper/codeableconcept/allergyResolved/";
     private static final String TEST_FILE_DIRECTORY_ALLERGY_ACTIVE = "/ehr/mapper/codeableconcept/allergyActive/";
+    //private static final String TEST_FILE_DIRECTORY_BLOOD_PRESSURE = "/ehr/mapper/codeableconcept/bloodPressure/";
     private static final String TEST_FILE_DIRECTORY_MEDICATION = "/ehr/mapper/codeableconcept/medication/";
 
     private static final String TEST_FILE_TOPIC_RELATED_CONDITION = TEST_FILE_DIRECTORY
@@ -62,6 +63,10 @@ public class CodeableConceptCdMapperTest {
     private static Stream<Arguments> getTestArgumentsAllergyActive() {
         return TestArgumentsLoaderUtil.readTestCases(TEST_FILE_DIRECTORY_ALLERGY_ACTIVE);
     }
+
+//    private static Stream<Arguments> getTestArgumentsBloodPressure() {
+//        return TestArgumentsLoaderUtil.readTestCases(TEST_FILE_DIRECTORY_BLOOD_PRESSURE);
+//    }
 
     private static Stream<Arguments> getTestArgumentsMedication() {
         return TestArgumentsLoaderUtil.readTestCases(TEST_FILE_DIRECTORY_MEDICATION);
@@ -226,6 +231,37 @@ public class CodeableConceptCdMapperTest {
             .describedAs(TestArgumentsLoaderUtil.FAIL_MESSAGE, inputJson, outputXml)
             .isEqualToIgnoringWhitespace(expectedOutput);
     }
+
+    @Test
+    void When_MappingStubbedCodableConceptWithoutCoding_Expect_NullFlavorCdXmlWithoutOriginalText() {
+        var inputJson = """
+            {
+                "resourceType": "Observation"
+            }""";
+        var expectedOutput = """
+            <code nullFlavor="UNK">
+            </code>""";
+        var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+
+        var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
+
+        assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+    }
+
+//    @ParameterizedTest
+//    @MethodSource("getTestArgumentsBloodPressure")
+//    void When_MappingStubbedCodeableConceptForBloodPressure_Expect_HL7CdObjectXml(String inputJson, String outputXml) {
+//        var allergyCodeableConcept = ResourceTestFileUtils.getFileContent(inputJson);
+//        var expectedOutput = ResourceTestFileUtils.getFileContent(outputXml);
+//        var codeableConcept = fhirParseService.parseResource(allergyCodeableConcept, AllergyIntolerance.class).getCode();
+//
+//        var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForAllergy(codeableConcept,
+//            AllergyIntolerance.AllergyIntoleranceClinicalStatus.ACTIVE);
+//
+//        assertThat(outputMessage)
+//            .describedAs(TestArgumentsLoaderUtil.FAIL_MESSAGE, inputJson, outputXml)
+//            .isEqualToIgnoringWhitespace(expectedOutput);
+//    }
 
     @ParameterizedTest
     @MethodSource("getTestArgumentsForTopicRelatedProblem")

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
@@ -777,8 +777,6 @@ public class CodeableConceptCdMapperTest {
         }
     }
 
-
-
     @ParameterizedTest
     @MethodSource("getTestArgumentsForTopicRelatedProblem")
     @SneakyThrows

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
@@ -230,7 +230,6 @@ public class CodeableConceptCdMapperTest {
 
     @Nested
     class WhenMappingStubbedCodeableConceptForBloodPressure {
-
         @Test
         void When_WithoutCoding_Expect_NullFlavorCdXmlWithoutOriginalText() {
             var inputJson = """
@@ -240,31 +239,6 @@ public class CodeableConceptCdMapperTest {
             var expectedOutput = """
             <code nullFlavor="UNK">
             </code>""";
-            var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
-
-            var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
-
-            assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
-        }
-
-        @Test
-        void When_WithNonSnomedCodingWithDisplay_Expect_NullFlavorCdXmlWithOriginalText() {
-            var inputJson = """
-                {
-                     "resourceType": "Observation",
-                     "code": {
-                         "coding": [
-                             {
-                                 "display": "Prothrombin time"
-                             }
-                         ]
-                     }
-                }""";
-
-            var expectedOutput = """
-                <code nullFlavor="UNK">
-                    <originalText>Prothrombin time</originalText>
-                </code>""";
             var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
 
             var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
@@ -290,33 +264,6 @@ public class CodeableConceptCdMapperTest {
             var expectedOutput = """
                 <code code="852471000000107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Prothrombin time">
                     <originalText>Prothrombin time</originalText>
-                </code>""";
-            var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
-
-            var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
-
-            assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
-        }
-
-        @Test
-        void When_WithSnomedCodingWithoutCode_Expect_SnomedCdXmlWithOriginalTextFromText() {
-            var inputJson = """
-                {
-                     "resourceType": "Observation",
-                     "code": {
-                         "coding": [
-                             {
-                                 "system": "http://snomed.info/sct",
-                                 "display": "Prothrombin time",
-                                 "code": "852471000000107"
-                             }
-                         ],
-                         "text": "Prothrombin time observed"
-                     }
-                }""";
-            var expectedOutput = """
-                <code code="852471000000107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Prothrombin time">
-                    <originalText>Prothrombin time observed</originalText>
                 </code>""";
             var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
 
@@ -397,7 +344,7 @@ public class CodeableConceptCdMapperTest {
         }
 
         @Test
-        void When_WithoutSnomedCodingWithText_Expect_NullFlavorUnkCDWithOriginalTextFromText() {
+        void When_WithNonSnomedCodingWithText_Expect_NullFlavorUnkCDWithOriginalTextFromText() {
             var inputJson = """
                 {
                      "resourceType": "Observation",
@@ -415,6 +362,33 @@ public class CodeableConceptCdMapperTest {
             var expectedOutput = """
                 <code nullFlavor="UNK">
                     <originalText>Prothrombin time (observed)</originalText>
+                </code>""";
+            var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+
+            var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
+
+            assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+        }
+
+        @Test
+        void When_WithNonSnomedCodingNoTextWithDisplay_Expect_NullFlavorCdXmlWithOriginalTextFromDisplay() {
+            var inputJson = """
+                {
+                     "resourceType": "Observation",
+                     "code": {
+                         "coding": [
+                             {
+                                 "system": "http://read.info/readv2",
+                                 "code": "42Q5.00",
+                                 "display": "Prothrombin time"
+                             }
+                         ]
+                     }
+                }""";
+
+            var expectedOutput = """
+                <code nullFlavor="UNK">
+                    <originalText>Prothrombin time</originalText>
                 </code>""";
             var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
 
@@ -500,43 +474,6 @@ public class CodeableConceptCdMapperTest {
 
     @Nested
     class WhenMappingToNullFlavorCodeableConcept {
-
-        @Test
-        void When_WithNonSnomedCodingWithNoDisplayNoTextAndDescriptionExtensionNoDisplayExtension_Expect_SnomedCdXmlWithoutOriginalText() {
-            var inputJson = """
-                {
-                    "resourceType": "Observation",
-                    "code": {
-                        "coding": [
-                            {
-                                "system": "http://read.info/readv2",
-                                "code": "42Q5.00",
-                                "extension": [
-                                    {
-                                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
-                                        "extension": [
-                                            {
-                                                "url": "descriptionId",
-                                                "valueString": "123456789"
-                                            }
-                                        ]
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                }""";
-
-            var expectedOutput = """
-                <code nullFlavor="UNK">
-                </code>""";
-            var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
-
-            var outputMessage = codeableConceptCdMapper.mapToNullFlavorCodeableConcept(codeableConcept);
-
-            assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
-        }
-
         @Test
         void When_WithSnomedCodingNoTextNoDisplayWithDescriptionExtensionWithDisplayExtension_Expect_SnomedCdXmlWithoutOriginalText() {
             var inputJson = """
@@ -676,7 +613,43 @@ public class CodeableConceptCdMapperTest {
         }
 
         @Test
-        void When_WithNonSnomedCodingWithNoTextWithDescriptionExtensionNoDisplayExtension_Expect_SnomedCdXmlWithOriginalTextFromDisplay() {
+        void When_WithNonSnomedCodingWithNoDisplayNoTextWithDescriptionExtNoDisplayExt_Expect_SnomedCdXmlWithoutOriginalText() {
+            var inputJson = """
+                {
+                    "resourceType": "Observation",
+                    "code": {
+                        "coding": [
+                            {
+                                "system": "http://read.info/readv2",
+                                "code": "42Q5.00",
+                                "extension": [
+                                    {
+                                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                        "extension": [
+                                            {
+                                                "url": "descriptionId",
+                                                "valueString": "123456789"
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }""";
+
+            var expectedOutput = """
+                <code nullFlavor="UNK">
+                </code>""";
+            var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+
+            var outputMessage = codeableConceptCdMapper.mapToNullFlavorCodeableConcept(codeableConcept);
+
+            assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+        }
+
+        @Test
+        void When_WithNonSnomedCodingWithDisplayNoTextWithDescriptionExtNoDisplayExt_Expect_SnomedCdXmlWithOriginalTextFromDisplay() {
             var inputJson = """
                 {
                     "resourceType": "Observation",


### PR DESCRIPTION
## What

* Add tests for existing functionality when mapping `CodeableConcept` for blood pressures.
* Slight refactor on `CodeableConceptCdMapper` for readability and allow testing around existing bug when retrieving the original text value from the display extension.

## Why

This method was untested and changes are required when handling non-SNOMEDCT codes.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes