### PR TITLE
NIAD-3153: Adding confidentialityCode to RequestStatement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* GP2GP Adaptor now populates the PlanStatement / confidentialityCode field 
-when the ProcedureRequest.meta.security field contains NOPAT and the message type is RCMR_IN030000UK07
+* GP2GP Adaptor now populates the PlanStatement / confidentialityCode field when the ProcedureRequest.meta.security field contains NOPAT
+* When the ReferralRequest.meta.security field contains NOPAT, the GP2GP Adaptor will now populate the RequestStatement / confidentialityCode field accordingly.
 
 ## [2.2.2] - 2025-02-07
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
@@ -62,8 +62,7 @@ public class CodeableConceptCdMapper {
 
     private String mapCodeableConcept(
         CodeableConcept codeableConcept,
-        BiFunction<Optional<List<Extension>>, Coding, Optional<String>> getMainCodeFunction
-    ) {
+        BiFunction<Optional<List<Extension>>, Coding, Optional<String>> getMainCodeFunction) {
         Optional<Coding> snomedCodeCoding = getSnomedCodeCoding(codeableConcept);
 
         if (snomedCodeCoding.isEmpty()) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/RequestStatementTemplateParameters.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/RequestStatementTemplateParameters.java
@@ -17,4 +17,5 @@ public class RequestStatementTemplateParameters {
     private String participant;
     private String responsibleParty;
     private String text;
+    private String confidentialityCode;
 }

--- a/service/src/main/resources/templates/ehr_request_statement_template.mustache
+++ b/service/src/main/resources/templates/ehr_request_statement_template.mustache
@@ -10,6 +10,9 @@
             <center nullFlavor="NI"/>
         </effectiveTime>
         {{{availabilityTime}}}
+        {{#confidentialityCode}}
+            {{{confidentialityCode}}}
+        {{/confidentialityCode}}
         {{#priorityCode}}
         {{{priorityCode}}}
         {{/priorityCode}}

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
@@ -187,7 +187,7 @@ public class EhrExtractMapperComponentTest {
                 codeableConceptCdMapper,
                 participantMapper
             ),
-            new RequestStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
+            new RequestStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService),
             new DiagnosticReportMapper(
                 messageContext, specimenMapper, participantMapper, randomIdGeneratorService, confidentialityService
             ),

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
@@ -181,7 +181,7 @@ public class EncounterComponentsMapperTest {
                 confidentialityService
             );
         RequestStatementMapper requestStatementMapper
-            = new RequestStatementMapper(messageContext, codeableConceptCdMapper, participantMapper);
+            = new RequestStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService);
         DiagnosticReportMapper diagnosticReportMapper = new DiagnosticReportMapper(
             messageContext, specimenMapper, participantMapper, randomIdGeneratorService, confidentialityService
         );

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
@@ -207,7 +207,7 @@ public class EhrExtractUATTest {
                 codeableConceptCdMapper,
                 participantMapper
             ),
-            new RequestStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
+            new RequestStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService),
             new DiagnosticReportMapper(messageContext, specimenMapper, participantMapper, randomIdGeneratorService, confidentialityService),
             new BloodPressureValidator(),
             codeableConceptCdMapper

--- a/service/src/test/resources/ehr/mapper/referral/example-referral-request-with-nopat.json
+++ b/service/src/test/resources/ehr/mapper/referral/example-referral-request-with-nopat.json
@@ -1,0 +1,36 @@
+{
+    "resourceType": "ReferralRequest",
+    "id": "E63AF323-919F-4D5F-9A1D-BA933BC230BC",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Immunization-1"
+        ],
+        "security": [{
+            "system":"http://hl7.org/fhir/v3/ActCode",
+            "code":"NOPAT",
+            "display":"no disclosure to patient, family or caregivers without attending provider's authorization"
+        }]
+    },
+    "authoredOn": "2010-01-19",
+    "priority": "routine",
+    "description": "Referred for investigation into low blood pressure",
+    "specialty": {
+        "coding": [
+            {
+                "system": "http://hl7.org/fhir/v3/NullFlavor",
+                "code": "UNK",
+                "display": "unknown"
+            }
+        ]
+    },
+    "identifier": [
+        {
+            "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+            "value": "B154D1A3-D631-49BD-8B67-2F76D7D85865"
+        },
+        {
+            "system": "https://fhir.nhs.uk/Id/ubr-number",
+            "value": "bb2378b6-dde2-11e9-9d36-2a2ae2dbcce4"
+        }
+    ]
+}


### PR DESCRIPTION
## What

Adding confidentialityCode to RequestStatement

## Why

When the ReferralRequest.meta.security field contains NOPAT and the message type is RCMR_IN030000UK07, the GP2GP Adaptor will now populate the RequestStatement / confidentialityCode field accordingly.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
