### PR TITLE
GP2GP Sending Adaptor not preserving legacy read codes on export for blood pressures

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
@@ -162,6 +162,7 @@ public class CodeableConceptCdMapper {
 
             code.ifPresent(builder::mainCode);
             displayText.ifPresent(builder::mainDisplayName);
+            builder.translations(getNonSnomedCodeCodings(codeableConcept));
         }
 
         return TemplateUtils.fillTemplate(CODEABLE_CONCEPT_CD_TEMPLATE, builder.build());

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
@@ -325,6 +325,44 @@ public class CodeableConceptCdMapperTest {
         }
 
         @Test
+        void When_WithSnomedCodingAndLegacyCodings_Expect_SnomedCdXmlWithTranslations() {
+            var inputJson = """
+                {
+                     "resourceType": "Observation",
+                     "code": {
+                         "coding": [
+                             {
+                                 "system": "http://snomed.info/sct",
+                                 "display": "Prothrombin time",
+                                 "code": "852471000000107"
+                             },
+                             {
+                                 "system": "http://read.info/readv2",
+                                 "code": "42Q5.00",
+                                 "display": "Observed Prothrombin time"
+                             },
+                             {
+                                 "system": "http://read.info/ctv3",
+                                 "code": "123456",
+                                 "display": "Prothrombin time (observed)"
+                             }
+                         ]
+                     }
+                }""";
+            var expectedOutput = """
+                <code code="852471000000107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Prothrombin time">
+                    <translation code="42Q5.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Observed Prothrombin time" />
+                    <translation code="123456" codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="Prothrombin time (observed)" />
+                    <originalText>Prothrombin time</originalText>
+                </code>""";
+            var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+
+            var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
+
+            assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+        }
+
+        @Test
         void When_WithNonSnomedCodingWithText_Expect_NullFlavorUnkCDWithOriginalTextFromText() {
             var inputJson = """
                 {
@@ -444,6 +482,37 @@ public class CodeableConceptCdMapperTest {
             var expectedOutput = """
                 <code nullFlavor="UNK">
                     <originalText>Prothrombin time (observed)</originalText>
+                </code>""";
+            var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+
+            var outputMessage = codeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(codeableConcept);
+
+            assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+        }
+
+        @Test
+        void When_WithoutSnomedCodingAndWithLegacyCodings_Expect_NullFlavorSnomedCdXmlWithoutTranslations() {
+            var inputJson = """
+                {
+                     "resourceType": "Observation",
+                     "code": {
+                         "coding": [
+                             {
+                                 "system": "http://read.info/readv2",
+                                 "code": "42Q5.00",
+                                 "display": "Observed Prothrombin time"
+                             },
+                             {
+                                 "system": "http://read.info/ctv3",
+                                 "code": "123456",
+                                 "display": "Prothrombin time (observed)"
+                             }
+                         ]
+                     }
+                }""";
+            var expectedOutput = """
+                <code nullFlavor="UNK">
+                    <originalText>Observed Prothrombin time</originalText>
                 </code>""";
             var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
 

--- a/service/src/test/resources/ehr/mapper/blood_pressure/blood-pressure-with-codeable-concepts.xml
+++ b/service/src/test/resources/ehr/mapper/blood_pressure/blood-pressure-with-codeable-concepts.xml
@@ -2,8 +2,9 @@
     <CompoundStatement classCode="BATTERY" moodCode="EVN">
         <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
         <code code="852471000000107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Prothrombin time">
-    <originalText>Prothrombin time</originalText>
-</code>
+            <translation code="42Q5.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Prothrombin time" />
+            <originalText>Prothrombin time</originalText>
+        </code>
         <statusCode code="COMPLETE"/>
         <effectiveTime>
             <center value="20121008104149"/>
@@ -13,8 +14,9 @@
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
                 <code code="72313002" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Systolic arterial pressure">
-    <originalText>Systolic arterial pressure</originalText>
-</code>
+                    <translation code="2469" codeSystem="2.16.840.1.113883.2.1.6.3" displayName="Systolic arterial pressure" />
+                    <originalText>Systolic arterial pressure</originalText>
+                </code>
                 <statusCode code="COMPLETE"/>
                 <effectiveTime>
                     <center value="20121008104149"/>
@@ -34,8 +36,9 @@
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
                 <code code="1091811000000102" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Diastolic arterial pressure">
-    <originalText>Diastolic arterial pressure</originalText>
-</code>
+                    <translation code="246A" codeSystem="2.16.840.1.113883.2.1.6.3" displayName="Diastolic arterial pressure" />
+                    <originalText>Diastolic arterial pressure</originalText>
+                </code>
                 <statusCode code="COMPLETE"/>
                 <effectiveTime>
                     <center value="20121008104149"/>


### PR DESCRIPTION
## What

* Add functionality when mapping blood pressures to preserve non snomed codes 
* Add tests to handle non snomed code translations

## Why

The GP2GP Sending Adaptor does not currently preserve non-SNOMEDCT codes when mapping CodeableConcepts.
The GP2GP Request Adaptor does preserve this codes when a SNOMEDCT code is also present in the coding block.
It is necessary as part of FRA that these are preserved when transferring a patient out of NME system.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
