### PR TITLE
* Update mongoDb version to version 4.0.28 in the transform tool docker file

### DIFF
--- a/docker/docker-compose-transform-tool.yml
+++ b/docker/docker-compose-transform-tool.yml
@@ -1,6 +1,6 @@
 services:
   mongodb:
-    image: mongo:3.6.23
+    image: mongo:4.0.28
     ports:
       - "27017:27017"
 


### PR DESCRIPTION
## What

* Update mongoDb version to version 4.0.28 in the transform tool docker file.
## Why

To resolve versioning issue between the driver used by the adaptor and the mongoDb set as part of the docker compose. This was previously completed in the main docker compose, but not upgraded for this tool.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes