### PR TITLE
NIAD-3153: Send over Observation (Blood Pressure).meta.security NOPAT field to incumbent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* GP2GP Adaptor now populates the PlanStatement / confidentialityCode field 
-when the ProcedureRequest.meta.security field contains NOPAT and the message type is RCMR_IN030000UK07
+* GP2GP Adaptor now populates the PlanStatement / confidentialityCode field when the ProcedureRequest.meta.security field contains NOPAT
+* When the ReferralRequest.meta.security field contains NOPAT, the GP2GP Adaptor will now populate the RequestStatement / confidentialityCode field accordingly.
 
 ## [2.2.2] - 2025-02-07
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapper.java
@@ -10,6 +10,7 @@ import org.hl7.fhir.dstu3.model.ResourceType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import uk.nhs.adaptors.gp2gp.common.service.ConfidentialityService;
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
 import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
 import uk.nhs.adaptors.gp2gp.ehr.mapper.parameters.BloodPressureParameters;
@@ -57,13 +58,18 @@ public class BloodPressureMapper {
     private final StructuredObservationValueMapper structuredObservationValueMapper;
     private final CodeableConceptCdMapper codeableConceptCdMapper;
     private final ParticipantMapper participantMapper;
+    private final ConfidentialityService confidentialityService;
 
     public String mapBloodPressure(Observation observation, boolean isNested) {
+
+        var confidentialityCode = confidentialityService.generateConfidentialityCode(observation);
+
         BloodPressureParametersBuilder builder = BloodPressureParameters.builder()
             .isNested(isNested)
             .id(messageContext.getIdMapper().getOrNew(ResourceType.Observation, observation.getIdElement()))
             .effectiveTime(prepareEffectiveTimeForObservation(observation))
             .availabilityTime(prepareAvailabilityTimeForObservation(observation))
+            .confidentialityCode(confidentialityCode.orElse(null))
             .compoundStatementCode(buildBloodPressureCode(observation));
 
         extractBloodPressureComponent(observation, SYSTOLIC_CODE).ifPresent(observationComponent -> {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
@@ -62,8 +62,7 @@ public class CodeableConceptCdMapper {
 
     private String mapCodeableConcept(
         CodeableConcept codeableConcept,
-        BiFunction<Optional<List<Extension>>, Coding, Optional<String>> getMainCodeFunction
-    ) {
+        BiFunction<Optional<List<Extension>>, Coding, Optional<String>> getMainCodeFunction) {
         Optional<Coding> snomedCodeCoding = getSnomedCodeCoding(codeableConcept);
 
         if (snomedCodeCoding.isEmpty()) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/BloodPressureParameters.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/BloodPressureParameters.java
@@ -23,4 +23,5 @@ public class BloodPressureParameters {
     private String systolicCode;
     private String diastolicCode;
     private String participant;
+    private String confidentialityCode;
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/RequestStatementTemplateParameters.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/RequestStatementTemplateParameters.java
@@ -17,4 +17,5 @@ public class RequestStatementTemplateParameters {
     private String participant;
     private String responsibleParty;
     private String text;
+    private String confidentialityCode;
 }

--- a/service/src/main/resources/templates/ehr_compound_statement_blood_pressure_template.mustache
+++ b/service/src/main/resources/templates/ehr_compound_statement_blood_pressure_template.mustache
@@ -7,6 +7,9 @@
             {{{effectiveTime}}}
         </effectiveTime>
         {{{availabilityTime}}}
+        {{#confidentialityCode}}
+            {{{confidentialityCode}}}
+        {{/confidentialityCode}}
         {{#systolicId}}
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">

--- a/service/src/main/resources/templates/ehr_request_statement_template.mustache
+++ b/service/src/main/resources/templates/ehr_request_statement_template.mustache
@@ -10,6 +10,9 @@
             <center nullFlavor="NI"/>
         </effectiveTime>
         {{{availabilityTime}}}
+        {{#confidentialityCode}}
+            {{{confidentialityCode}}}
+        {{/confidentialityCode}}
         {{#priorityCode}}
         {{{priorityCode}}}
         {{/priorityCode}}

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
@@ -161,7 +161,7 @@ public class EhrExtractMapperComponentTest {
             new AllergyStructureMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService),
             new BloodPressureMapper(
                 messageContext, randomIdGeneratorService, new StructuredObservationValueMapper(),
-                codeableConceptCdMapper, new ParticipantMapper()),
+                codeableConceptCdMapper, new ParticipantMapper(), confidentialityService),
             new ConditionLinkSetMapper(
                 messageContext, randomIdGeneratorService, codeableConceptCdMapper, participantMapper, confidentialityService),
             new DiaryPlanStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService),

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
@@ -187,7 +187,7 @@ public class EhrExtractMapperComponentTest {
                 codeableConceptCdMapper,
                 participantMapper
             ),
-            new RequestStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
+            new RequestStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService),
             new DiagnosticReportMapper(
                 messageContext, specimenMapper, participantMapper, randomIdGeneratorService, confidentialityService
             ),

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
@@ -181,7 +181,7 @@ public class EncounterComponentsMapperTest {
                 confidentialityService
             );
         RequestStatementMapper requestStatementMapper
-            = new RequestStatementMapper(messageContext, codeableConceptCdMapper, participantMapper);
+            = new RequestStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService);
         DiagnosticReportMapper diagnosticReportMapper = new DiagnosticReportMapper(
             messageContext, specimenMapper, participantMapper, randomIdGeneratorService, confidentialityService
         );

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
@@ -143,7 +143,8 @@ public class EncounterComponentsMapperTest {
             randomIdGeneratorService,
             structuredObservationValueMapper,
             codeableConceptCdMapper,
-            participantMapper
+            participantMapper,
+            confidentialityService
         );
         ConditionLinkSetMapper conditionLinkSetMapper = new ConditionLinkSetMapper(messageContext,
             randomIdGeneratorService,

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
@@ -181,7 +181,7 @@ public class EhrExtractUATTest {
             new AllergyStructureMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService),
             new BloodPressureMapper(
                 messageContext, randomIdGeneratorService, new StructuredObservationValueMapper(),
-                codeableConceptCdMapper, new ParticipantMapper()),
+                codeableConceptCdMapper, new ParticipantMapper(), confidentialityService),
             new ConditionLinkSetMapper(
                 messageContext, randomIdGeneratorService, codeableConceptCdMapper, participantMapper, confidentialityService),
             new DiaryPlanStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService),

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
@@ -207,7 +207,7 @@ public class EhrExtractUATTest {
                 codeableConceptCdMapper,
                 participantMapper
             ),
-            new RequestStatementMapper(messageContext, codeableConceptCdMapper, participantMapper),
+            new RequestStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService),
             new DiagnosticReportMapper(messageContext, specimenMapper, participantMapper, randomIdGeneratorService, confidentialityService),
             new BloodPressureValidator(),
             codeableConceptCdMapper

--- a/service/src/test/resources/ehr/mapper/blood_pressure/blood-pressure-with-nopat.json
+++ b/service/src/test/resources/ehr/mapper/blood_pressure/blood-pressure-with-nopat.json
@@ -1,0 +1,154 @@
+{
+    "resourceType": "Observation",
+    "id": "296D5D73-8D65-4CAC-8047-553232F77A82",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DiagnosticReport-1"
+        ],
+        "security": [
+            {
+                "system": "http://hl7.org/fhir/v3/ActCode",
+                "code": "NOPAT",
+                "display": "no disclosure to patient, family or caregivers without attending provider's authorization"
+            }
+        ]
+    },
+    "identifier": [
+        {
+            "system": "https://EMISWeb/A82038",
+            "value": "296D5D73-8D65-4CAC-8047-553232F77A82"
+        }
+    ],
+    "status": "final",
+    "code": {
+        "coding": [
+            {
+                "system": "http://read.info/readv2",
+                "code": "42Q5.00",
+                "display": "Prothrombin time",
+                "userSelected": true
+            },
+            {
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                        "extension": [
+                            {
+                                "url": "descriptionId",
+                                "valueId": "2207951000000110"
+                            }
+                        ]
+                    }
+                ],
+                "system": "http://snomed.info/sct",
+                "code": "852471000000107",
+                "display": "Prothrombin time"
+            }
+        ]
+    },
+    "component": [
+        {
+            "code": {
+                "coding": [
+                    {
+                        "system": "https://fhir.hl7.org.uk/Id/egton-codes",
+                        "code": "2469",
+                        "display": "Systolic blood pressure",
+                        "userSelected": true
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                "extension": [
+                                    {
+                                        "url": "descriptionId",
+                                        "valueId": "120159016"
+                                    },
+                                    {
+                                        "url": "descriptionDisplay",
+                                        "valueString": "Systolic blood pressure"
+                                    }
+                                ]
+                            }
+                        ],
+                        "system": "http://snomed.info/sct",
+                        "code": "271649006",
+                        "display": "Systolic blood pressure"
+                    }
+                ]
+            },
+            "valueQuantity": {
+                "value": 110,
+                "unit": "mm[Hg]"
+            },
+            "interpretation": {
+                "text": "Systolic blood pressure interpretation text"
+            }
+        },
+        {
+            "code": {
+                "coding": [
+                    {
+                        "system": "https://fhir.hl7.org.uk/Id/egton-codes",
+                        "code": "246A",
+                        "display": "Diastolic blood pressure",
+                        "userSelected": true
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                "extension": [
+                                    {
+                                        "url": "descriptionId",
+                                        "valueId": "271650006"
+                                    },
+                                    {
+                                        "url": "descriptionDisplay",
+                                        "valueString": "Diastolic blood pressure"
+                                    }
+                                ]
+                            }
+                        ],
+                        "system": "http://snomed.info/sct",
+                        "code": "271650006",
+                        "display": "Diastolic blood pressure"
+                    }
+                ]
+            },
+            "valueQuantity": {
+                "value": 55,
+                "unit": "mm[Hg]"
+            },
+            "interpretation": {
+                "coding": [
+                    {
+                        "display": "Diastolic blood pressure interpretation display"
+                    }
+                ]
+            }
+        }
+    ],
+    "subject": {
+        "reference": "Patient/7CCF0FBE-C849-4BA2-A7DD-9907D1676161"
+    },
+    "context": {
+        "reference": "Encounter/41882B34-B22F-4A5B-970E-75CF7846A629"
+    },
+    "effectiveDateTime": "2013-11-18T09:41:49.46+00:00",
+    "issued": "2013-11-18T09:41:49.46+00:00",
+    "performer": [
+        {
+            "reference": "Practitioner/749107A2-4975-441F-8EDF-ADFF451FD12D"
+        }
+    ],
+    "comment": "blood pressure is very low",
+    "bodySite": {
+        "coding": [
+            {
+                "display": "Body site display"
+            }
+        ]
+    }
+}

--- a/service/src/test/resources/ehr/mapper/blood_pressure/blood-pressure-with-nopat.xml
+++ b/service/src/test/resources/ehr/mapper/blood_pressure/blood-pressure-with-nopat.xml
@@ -1,0 +1,52 @@
+<component typeCode="COMP" contextConductionInd="true">
+    <CompoundStatement classCode="BATTERY" moodCode="EVN">
+        <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
+        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center value="20131118094149"/>
+        </effectiveTime>
+        <availabilityTime value="20131118094149"/>
+        <confidentialityCode
+          code="NOPAT"
+          codeSystem="2.16.840.1.113883.4.642.3.47"
+          displayName="no disclosure to patient, family or caregivers without attending provider's authorization" />
+        <component typeCode="COMP" contextConductionInd="true">
+            <ObservationStatement classCode="OBS" moodCode="EVN">
+                <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
+                <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <center value="20131118094149"/>
+                </effectiveTime>
+                <availabilityTime value="20131118094149"/>
+                <value xsi:type="PQ" value="110" unit="1"><translation value="110"><originalText>mm[Hg]</originalText></translation></value>
+            </ObservationStatement>
+        </component>
+        <component typeCode="COMP" contextConductionInd="true">
+            <ObservationStatement classCode="OBS" moodCode="EVN">
+                <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
+                <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <center value="20131118094149"/>
+                </effectiveTime>
+                <availabilityTime value="20131118094149"/>
+                <value xsi:type="PQ" value="55" unit="1"><translation value="55"><originalText>mm[Hg]</originalText></translation></value>
+            </ObservationStatement>
+        </component>
+        <component typeCode="COMP" contextConductionInd="true">
+            <NarrativeStatement classCode="OBS" moodCode="EVN">
+                <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
+                <text>blood pressure is very low Measurement Site: Body site display Interpretation(s): Systolic blood pressure interpretation text, Diastolic blood pressure interpretation display</text>
+                <statusCode code="COMPLETE"/>
+                <availabilityTime value="20131118094149"/>
+            </NarrativeStatement>
+        </component>
+        <Participant typeCode="PRF" contextControlCode="OP">
+    <agentRef classCode="AGNT">
+        <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
+    </agentRef>
+</Participant>
+    </CompoundStatement>
+</component>

--- a/service/src/test/resources/ehr/mapper/referral/example-referral-request-with-nopat.json
+++ b/service/src/test/resources/ehr/mapper/referral/example-referral-request-with-nopat.json
@@ -1,0 +1,36 @@
+{
+    "resourceType": "ReferralRequest",
+    "id": "E63AF323-919F-4D5F-9A1D-BA933BC230BC",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Immunization-1"
+        ],
+        "security": [{
+            "system":"http://hl7.org/fhir/v3/ActCode",
+            "code":"NOPAT",
+            "display":"no disclosure to patient, family or caregivers without attending provider's authorization"
+        }]
+    },
+    "authoredOn": "2010-01-19",
+    "priority": "routine",
+    "description": "Referred for investigation into low blood pressure",
+    "specialty": {
+        "coding": [
+            {
+                "system": "http://hl7.org/fhir/v3/NullFlavor",
+                "code": "UNK",
+                "display": "unknown"
+            }
+        ]
+    },
+    "identifier": [
+        {
+            "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+            "value": "B154D1A3-D631-49BD-8B67-2F76D7D85865"
+        },
+        {
+            "system": "https://fhir.nhs.uk/Id/ubr-number",
+            "value": "bb2378b6-dde2-11e9-9d36-2a2ae2dbcce4"
+        }
+    ]
+}


### PR DESCRIPTION
## What

Send over Observation (Blood Pressure).meta.security NOPAT field to incumbent

## Why

The GP2GP Adaptor now populates the CompoundStatement / confidentialityCode field when Observation.meta.security is set to NOPAT and the message type is RCMR_IN030000UK07

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
