### PR TITLE
NIAD-3154: CompoundStatement confidentialityCode field is populated when Observation.meta.security field contains NOPAT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ In the case that neither of these are present, the existing behavior of using th
 
 * GP2GP Adaptor now populates the PlanStatement / confidentialityCode field when the ProcedureRequest.meta.security field contains NOPAT
 * When the ReferralRequest.meta.security field contains NOPAT, the GP2GP Adaptor will now populate the RequestStatement / confidentialityCode field accordingly.
+* The GP2GP Adaptor now populates the CompoundStatement / confidentialityCode field when Observation.meta.security field contains NOPAT
 
 ## [2.2.2] - 2025-02-07
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapper.java
@@ -10,6 +10,7 @@ import org.hl7.fhir.dstu3.model.ResourceType;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import uk.nhs.adaptors.gp2gp.common.service.ConfidentialityService;
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
 import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
 import uk.nhs.adaptors.gp2gp.ehr.mapper.parameters.BloodPressureParameters;
@@ -57,13 +58,18 @@ public class BloodPressureMapper {
     private final StructuredObservationValueMapper structuredObservationValueMapper;
     private final CodeableConceptCdMapper codeableConceptCdMapper;
     private final ParticipantMapper participantMapper;
+    private final ConfidentialityService confidentialityService;
 
     public String mapBloodPressure(Observation observation, boolean isNested) {
+
+        var confidentialityCode = confidentialityService.generateConfidentialityCode(observation);
+
         BloodPressureParametersBuilder builder = BloodPressureParameters.builder()
             .isNested(isNested)
             .id(messageContext.getIdMapper().getOrNew(ResourceType.Observation, observation.getIdElement()))
             .effectiveTime(prepareEffectiveTimeForObservation(observation))
             .availabilityTime(prepareAvailabilityTimeForObservation(observation))
+            .confidentialityCode(confidentialityCode.orElse(null))
             .compoundStatementCode(buildBloodPressureCode(observation));
 
         extractBloodPressureComponent(observation, SYSTOLIC_CODE).ifPresent(observationComponent -> {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/BloodPressureParameters.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/BloodPressureParameters.java
@@ -23,4 +23,5 @@ public class BloodPressureParameters {
     private String systolicCode;
     private String diastolicCode;
     private String participant;
+    private String confidentialityCode;
 }

--- a/service/src/main/resources/templates/ehr_compound_statement_blood_pressure_template.mustache
+++ b/service/src/main/resources/templates/ehr_compound_statement_blood_pressure_template.mustache
@@ -7,6 +7,9 @@
             {{{effectiveTime}}}
         </effectiveTime>
         {{{availabilityTime}}}
+        {{#confidentialityCode}}
+            {{{confidentialityCode}}}
+        {{/confidentialityCode}}
         {{#systolicId}}
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapperTest.java
@@ -13,14 +13,14 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import uk.nhs.adaptors.gp2gp.common.service.ConfidentialityService;
 import uk.nhs.adaptors.gp2gp.common.service.FhirParseService;
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
 import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
 import uk.nhs.adaptors.gp2gp.utils.CodeableConceptMapperMockUtil;
 import uk.nhs.adaptors.gp2gp.utils.ResourceTestFileUtils;
 import uk.nhs.adaptors.gp2gp.utils.TestArgumentsLoaderUtil;
-
-import java.io.IOException;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,6 +43,8 @@ public class BloodPressureMapperTest {
     private static final String EXPECTED_ARTERIAL_PRESSURE_WITHOUT_DATA = "arterial-pressure-without-data.xml";
     private static final String INPUT_BLOOD_PRESSURE_WITH_DATA = "blood-pressure-with-data.json";
     private static final String EXPECTED_BLOOD_PRESSURE_WITH_DATA = "blood-pressure-with-data.xml";
+    private static final String INPUT_BLOOD_PRESSURE_WITH_NOPAT = "blood-pressure-with-nopat.json";
+    private static final String EXPECTED_NESTED_BLOOD_PRESSURE_WITH_CONFIDENTIALITY_CODE = "blood-pressure-with-nopat.xml";
     private static final String EXPECTED_NESTED_BLOOD_PRESSURE = "blood-pressure-with-data-nested.xml";
     private static final String INPUT_BLOOD_PRESSURE_WITHOUT_DATA = "blood-pressure-without-data.json";
     private static final String EXPECTED_BLOOD_PRESSURE_WITHOUT_DATA = "blood-pressure-without-data.xml";
@@ -60,10 +62,18 @@ public class BloodPressureMapperTest {
     private static final String EXPECTED_BLOOD_PRESSURE_WITH_CODEABLE_CONCEPTS = "blood-pressure-with-codeable-concepts.xml";
     private static final String INPUT_BLOOD_PRESSURE_WITH_NO_CODEABLE_CONCEPTS = "blood-pressure-with-no-codeable-concepts.json";
 
+    public static final String CONFIDENTIALITY_CODE =
+        "<confidentialityCode code=\"NOPAT\" "
+        + "codeSystem=\"2.16.840.1.113883.4.642.3.47\" "
+        + "displayName=\"no disclosure to patient, family or caregivers without attending provider's authorization\" />";
+
     @Mock
     private RandomIdGeneratorService randomIdGeneratorService;
     @Mock
     private CodeableConceptCdMapper mockCodeableConceptCdMapper;
+
+    @Mock
+    private ConfidentialityService confidentialityService;
 
     private MessageContext messageContext;
     private BloodPressureMapper bloodPressureMapper;
@@ -76,7 +86,7 @@ public class BloodPressureMapperTest {
         messageContext.initialize(new Bundle());
         bloodPressureMapper = new BloodPressureMapper(
             messageContext, randomIdGeneratorService, new StructuredObservationValueMapper(),
-            mockCodeableConceptCdMapper, new ParticipantMapper());
+            mockCodeableConceptCdMapper, new ParticipantMapper(), confidentialityService);
     }
 
     @AfterEach
@@ -85,7 +95,24 @@ public class BloodPressureMapperTest {
     }
 
     @Test
-    public void When_MappingEmptyObservation_Expect_CompoundStatementXmlReturned() throws IOException {
+    public void When_MappingBloodPressureWithNopat_Expect_CompoundStatementWithConfidentialityCode() {
+        when(mockCodeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(any(CodeableConcept.class)))
+            .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
+
+        var jsonInput = ResourceTestFileUtils.getFileContent(BLOOD_PRESSURE_FILE_LOCATION + INPUT_BLOOD_PRESSURE_WITH_NOPAT);
+        var expectedOutput = ResourceTestFileUtils.getFileContent(BLOOD_PRESSURE_FILE_LOCATION
+                                                                  + EXPECTED_NESTED_BLOOD_PRESSURE_WITH_CONFIDENTIALITY_CODE);
+
+        Observation observation = new FhirParseService().parseResource(jsonInput, Observation.class);
+        when(confidentialityService.generateConfidentialityCode(observation)).thenReturn(Optional.of(CONFIDENTIALITY_CODE));
+
+        var outputMessage = bloodPressureMapper.mapBloodPressure(observation, true);
+
+        assertThat(outputMessage).isEqualToIgnoringWhitespace(expectedOutput);
+    }
+
+    @Test
+    public void When_MappingEmptyObservation_Expect_CompoundStatementXmlReturned() {
         when(mockCodeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(any(CodeableConcept.class)))
             .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
 
@@ -99,7 +126,7 @@ public class BloodPressureMapperTest {
     }
 
     @Test
-    public void When_MappingBloodPressureWithNestedTrue_Expect_CompoundStatementXmlReturned() throws IOException {
+    public void When_MappingBloodPressureWithNestedTrue_Expect_CompoundStatementXmlReturned() {
         when(mockCodeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(any(CodeableConcept.class)))
             .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
 
@@ -114,7 +141,7 @@ public class BloodPressureMapperTest {
 
     @ParameterizedTest
     @MethodSource("testArguments")
-    public void When_MappingBloodPressure_Expect_CompoundStatementXmlReturned(String inputJson, String outputXml) throws IOException {
+    public void When_MappingBloodPressure_Expect_CompoundStatementXmlReturned(String inputJson, String outputXml) {
         when(mockCodeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(any(CodeableConcept.class)))
             .thenReturn(CodeableConceptMapperMockUtil.NULL_FLAVOR_CODE);
 
@@ -144,7 +171,7 @@ public class BloodPressureMapperTest {
     }
 
     @Test
-    public void When_MappingBloodPressureWithCodeableConcepts_Expect_CompoundStatementXmlReturned() throws IOException {
+    public void When_MappingBloodPressureWithCodeableConcepts_Expect_CompoundStatementXmlReturned() {
         when(randomIdGeneratorService.createNewOrUseExistingUUID(any()))
             .thenReturn("5E496953-065B-41F2-9577-BE8F2FBD0757");
 
@@ -155,7 +182,7 @@ public class BloodPressureMapperTest {
         CodeableConceptCdMapper codeableConceptCdMapper = new CodeableConceptCdMapper();
         bloodPressureMapper = new BloodPressureMapper(
             messageContext, randomIdGeneratorService, new StructuredObservationValueMapper(),
-            codeableConceptCdMapper, new ParticipantMapper());
+            codeableConceptCdMapper, new ParticipantMapper(), confidentialityService);
 
         Observation observation = new FhirParseService().parseResource(jsonInput, Observation.class);
         var outputMessage = bloodPressureMapper.mapBloodPressure(observation, true);
@@ -164,13 +191,13 @@ public class BloodPressureMapperTest {
     }
 
     @Test
-    public void When_MappingBloodPressureWithNoCodeableConcepts_Expect_Exception() throws IOException {
+    public void When_MappingBloodPressureWithNoCodeableConcepts_Expect_Exception() {
         var jsonInput = ResourceTestFileUtils.getFileContent(BLOOD_PRESSURE_FILE_LOCATION + INPUT_BLOOD_PRESSURE_WITH_NO_CODEABLE_CONCEPTS);
 
         CodeableConceptCdMapper codeableConceptCdMapper = new CodeableConceptCdMapper();
         bloodPressureMapper = new BloodPressureMapper(
             messageContext, randomIdGeneratorService, new StructuredObservationValueMapper(),
-            codeableConceptCdMapper, new ParticipantMapper());
+            codeableConceptCdMapper, new ParticipantMapper(), confidentialityService);
 
         Observation observation = new FhirParseService().parseResource(jsonInput, Observation.class);
 

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
@@ -161,7 +161,7 @@ public class EhrExtractMapperComponentTest {
             new AllergyStructureMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService),
             new BloodPressureMapper(
                 messageContext, randomIdGeneratorService, new StructuredObservationValueMapper(),
-                codeableConceptCdMapper, new ParticipantMapper()),
+                codeableConceptCdMapper, new ParticipantMapper(), confidentialityService),
             new ConditionLinkSetMapper(
                 messageContext, randomIdGeneratorService, codeableConceptCdMapper, participantMapper, confidentialityService),
             new DiaryPlanStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService),

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
@@ -143,7 +143,8 @@ public class EncounterComponentsMapperTest {
             randomIdGeneratorService,
             structuredObservationValueMapper,
             codeableConceptCdMapper,
-            participantMapper
+            participantMapper,
+            confidentialityService
         );
         ConditionLinkSetMapper conditionLinkSetMapper = new ConditionLinkSetMapper(messageContext,
             randomIdGeneratorService,

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
@@ -181,7 +181,7 @@ public class EhrExtractUATTest {
             new AllergyStructureMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService),
             new BloodPressureMapper(
                 messageContext, randomIdGeneratorService, new StructuredObservationValueMapper(),
-                codeableConceptCdMapper, new ParticipantMapper()),
+                codeableConceptCdMapper, new ParticipantMapper(), confidentialityService),
             new ConditionLinkSetMapper(
                 messageContext, randomIdGeneratorService, codeableConceptCdMapper, participantMapper, confidentialityService),
             new DiaryPlanStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService),

--- a/service/src/test/resources/ehr/mapper/blood_pressure/blood-pressure-with-nopat.json
+++ b/service/src/test/resources/ehr/mapper/blood_pressure/blood-pressure-with-nopat.json
@@ -1,0 +1,154 @@
+{
+  "resourceType": "Observation",
+  "id": "296D5D73-8D65-4CAC-8047-553232F77A82",
+  "meta": {
+    "profile": [
+      "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-DiagnosticReport-1"
+    ],
+    "security": [
+      {
+        "system": "http://hl7.org/fhir/v3/ActCode",
+        "code": "NOPAT",
+        "display": "no disclosure to patient, family or caregivers without attending provider's authorization"
+      }
+    ]
+  },
+  "identifier": [
+    {
+      "system": "https://EMISWeb/A82038",
+      "value": "296D5D73-8D65-4CAC-8047-553232F77A82"
+    }
+  ],
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "system": "http://read.info/readv2",
+        "code": "42Q5.00",
+        "display": "Prothrombin time",
+        "userSelected": true
+      },
+      {
+        "extension": [
+          {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+            "extension": [
+              {
+                "url": "descriptionId",
+                "valueId": "2207951000000110"
+              }
+            ]
+          }
+        ],
+        "system": "http://snomed.info/sct",
+        "code": "852471000000107",
+        "display": "Prothrombin time"
+      }
+    ]
+  },
+  "component": [
+    {
+      "code": {
+        "coding": [
+          {
+            "system": "https://fhir.hl7.org.uk/Id/egton-codes",
+            "code": "2469",
+            "display": "Systolic blood pressure",
+            "userSelected": true
+          },
+          {
+            "extension": [
+              {
+                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                "extension": [
+                  {
+                    "url": "descriptionId",
+                    "valueId": "120159016"
+                  },
+                  {
+                    "url": "descriptionDisplay",
+                    "valueString": "Systolic blood pressure"
+                  }
+                ]
+              }
+            ],
+            "system": "http://snomed.info/sct",
+            "code": "271649006",
+            "display": "Systolic blood pressure"
+          }
+        ]
+      },
+      "valueQuantity": {
+        "value": 110,
+        "unit": "mm[Hg]"
+      },
+      "interpretation": {
+        "text": "Systolic blood pressure interpretation text"
+      }
+    },
+    {
+      "code": {
+        "coding": [
+          {
+            "system": "https://fhir.hl7.org.uk/Id/egton-codes",
+            "code": "246A",
+            "display": "Diastolic blood pressure",
+            "userSelected": true
+          },
+          {
+            "extension": [
+              {
+                "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                "extension": [
+                  {
+                    "url": "descriptionId",
+                    "valueId": "271650006"
+                  },
+                  {
+                    "url": "descriptionDisplay",
+                    "valueString": "Diastolic blood pressure"
+                  }
+                ]
+              }
+            ],
+            "system": "http://snomed.info/sct",
+            "code": "271650006",
+            "display": "Diastolic blood pressure"
+          }
+        ]
+      },
+      "valueQuantity": {
+        "value": 55,
+        "unit": "mm[Hg]"
+      },
+      "interpretation": {
+        "coding": [
+          {
+            "display": "Diastolic blood pressure interpretation display"
+          }
+        ]
+      }
+    }
+  ],
+  "subject": {
+    "reference": "Patient/7CCF0FBE-C849-4BA2-A7DD-9907D1676161"
+  },
+  "context": {
+    "reference": "Encounter/41882B34-B22F-4A5B-970E-75CF7846A629"
+  },
+  "effectiveDateTime": "2013-11-18T09:41:49.46+00:00",
+  "issued": "2013-11-18T09:41:49.46+00:00",
+  "performer": [
+    {
+      "reference": "Practitioner/749107A2-4975-441F-8EDF-ADFF451FD12D"
+    }
+  ],
+  "comment": "blood pressure is very low",
+  "bodySite": {
+    "coding": [
+      {
+        "display": "Body site display"
+      }
+    ]
+  }
+}

--- a/service/src/test/resources/ehr/mapper/blood_pressure/blood-pressure-with-nopat.xml
+++ b/service/src/test/resources/ehr/mapper/blood_pressure/blood-pressure-with-nopat.xml
@@ -1,0 +1,52 @@
+<component typeCode="COMP" contextConductionInd="true">
+    <CompoundStatement classCode="BATTERY" moodCode="EVN">
+        <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
+        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center value="20131118094149"/>
+        </effectiveTime>
+        <availabilityTime value="20131118094149"/>
+        <confidentialityCode
+          code="NOPAT"
+          codeSystem="2.16.840.1.113883.4.642.3.47"
+          displayName="no disclosure to patient, family or caregivers without attending provider's authorization" />
+        <component typeCode="COMP" contextConductionInd="true">
+            <ObservationStatement classCode="OBS" moodCode="EVN">
+                <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
+                <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <center value="20131118094149"/>
+                </effectiveTime>
+                <availabilityTime value="20131118094149"/>
+                <value xsi:type="PQ" value="110" unit="1"><translation value="110"><originalText>mm[Hg]</originalText></translation></value>
+            </ObservationStatement>
+        </component>
+        <component typeCode="COMP" contextConductionInd="true">
+            <ObservationStatement classCode="OBS" moodCode="EVN">
+                <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
+                <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+                <statusCode code="COMPLETE"/>
+                <effectiveTime>
+                    <center value="20131118094149"/>
+                </effectiveTime>
+                <availabilityTime value="20131118094149"/>
+                <value xsi:type="PQ" value="55" unit="1"><translation value="55"><originalText>mm[Hg]</originalText></translation></value>
+            </ObservationStatement>
+        </component>
+        <component typeCode="COMP" contextConductionInd="true">
+            <NarrativeStatement classCode="OBS" moodCode="EVN">
+                <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
+                <text>blood pressure is very low Measurement Site: Body site display Interpretation(s): Systolic blood pressure interpretation text, Diastolic blood pressure interpretation display</text>
+                <statusCode code="COMPLETE"/>
+                <availabilityTime value="20131118094149"/>
+            </NarrativeStatement>
+        </component>
+        <Participant typeCode="PRF" contextControlCode="OP">
+    <agentRef classCode="AGNT">
+        <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
+    </agentRef>
+</Participant>
+    </CompoundStatement>
+</component>


### PR DESCRIPTION
## What

The GP2GP Adaptor now populates the CompoundStatement / confidentialityCode field when Observation.meta.security field contains NOPAT

## Why

The GP2GP Adaptor now populates the CompoundStatement / confidentialityCode field when Observation.meta.security field contains NOPAT

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
