### PR TITLE
NIAD-3304: Ensure correct ordering of `originalText` when mapping `CodeableConcept` to `CD`

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
@@ -1,5 +1,6 @@
 package uk.nhs.adaptors.gp2gp.ehr.mapper;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -316,12 +317,17 @@ public class CodeableConceptCdMapper {
             .filter(coding -> !isSnomed(coding))
             .toList();
 
+        List<Coding> nonSnomedCodings = new ArrayList<>();
+
         for (Coding coding : nonSnomedCodeCodings) {
             var hl7CodeSystem = CodeSystemsUtil.getHl7code(coding.getSystem());
-            coding.setSystem(hl7CodeSystem);
+            if (!hl7CodeSystem.isEmpty()) {
+                coding.setSystem(hl7CodeSystem);
+                nonSnomedCodings.add(coding);
+            }
         }
 
-        return nonSnomedCodeCodings;
+        return nonSnomedCodings;
     }
 
     private Optional<String> findOriginalText(CodeableConcept codeableConcept, Optional<Coding> coding) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapper.java
@@ -322,8 +322,7 @@ public class CodeableConceptCdMapper {
         for (Coding coding : nonSnomedCodeCodings) {
             var hl7CodeSystem = CodeSystemsUtil.getHl7code(coding.getSystem());
             if (!hl7CodeSystem.isEmpty()) {
-                coding.setSystem(hl7CodeSystem);
-                nonSnomedCodings.add(coding);
+                nonSnomedCodings.add(new Coding(hl7CodeSystem, coding.getCode(), coding.getDisplay()));
             }
         }
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/utils/CodeSystemsUtil.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/utils/CodeSystemsUtil.java
@@ -12,10 +12,11 @@ public final class CodeSystemsUtil {
         "http://snomed.info/sct", "2.16.840.1.113883.2.1.3.2.4.15",
         "https://fhir.hl7.org.uk/Id/egton-codes", "2.16.840.1.113883.2.1.6.3",
         "http://read.info/readv2", "2.16.840.1.113883.2.1.6.2",
-        "http://read.info/ctv3", "2.16.840.1.113883.2.1.3.2.4.14"
+        "http://read.info/ctv3", "2.16.840.1.113883.2.1.3.2.4.14",
+        "https://fhir.hl7.org.uk/Id/emis-drug-codes", "2.16.840.1.113883.2.1.6.9"
     );
 
     public static String getHl7code(String fhirCodeSystem) {
-        return SYSTEM_CODES.getOrDefault(fhirCodeSystem, fhirCodeSystem);
+        return SYSTEM_CODES.getOrDefault(fhirCodeSystem, "");
     }
 }

--- a/service/src/main/resources/templates/codeable_concept_cd_template.mustache
+++ b/service/src/main/resources/templates/codeable_concept_cd_template.mustache
@@ -1,8 +1,8 @@
 <code{{#nullFlavor}} nullFlavor="UNK"{{/nullFlavor}}{{^nullFlavor}} code="{{mainCode}}" codeSystem="{{mainCodeSystem}}" displayName="{{mainDisplayName}}"{{/nullFlavor}}>
+    {{#mainOriginalText}}
+        <originalText>{{mainOriginalText}}</originalText>
+    {{/mainOriginalText}}
     {{#translations}}
     <translation code="{{code}}" codeSystem="{{system}}" displayName="{{display}}" />
     {{/translations}}
-    {{#mainOriginalText}}
-    <originalText>{{mainOriginalText}}</originalText>
-    {{/mainOriginalText}}
 </code>

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
@@ -124,6 +124,36 @@ public class CodeableConceptCdMapperTest {
     }
 
     @Test
+    void When_MappingCodeableConceptWithUnknownNonSnomedCodeSystem_Expect_ManifestedXmlDoesNotContainTranslations() {
+        var inputJson = """
+            {
+                "resourceType" : "Observation",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "123456",
+                            "display": "Endometriosis of uterus"
+                        },
+                        {
+                            "system": "http://unknown.code/systen",
+                            "code": "UNKNOWN01",
+                            "display": "Unknown Code System Display"
+                        }
+                   ]
+                }
+            }""";
+        var expectedOutputXml = """
+            <code code="123456" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Endometriosis of uterus">
+            </code>""";
+        var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
+
+        var outputMessageXml = codeableConceptCdMapper.mapCodeableConceptToCd(codeableConcept);
+
+        assertThat(outputMessageXml).isEqualToIgnoringWhitespace(expectedOutputXml);
+    }
+
+    @Test
     void When_MapToNullFlavorCodeableConceptForAllergyWithoutSnomedCode_Expect_OriginalTextIsNotPresent() {
         var inputJson = """
             {

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/CodeableConceptCdMapperTest.java
@@ -351,9 +351,9 @@ public class CodeableConceptCdMapperTest {
                 }""";
             var expectedOutput = """
                 <code code="852471000000107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Prothrombin time">
+                    <originalText>Prothrombin time</originalText>
                     <translation code="42Q5.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Observed Prothrombin time" />
                     <translation code="123456" codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="Prothrombin time (observed)" />
-                    <originalText>Prothrombin time</originalText>
                 </code>""";
             var codeableConcept = fhirParseService.parseResource(inputJson, Observation.class).getCode();
 

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/CodeSystemUtilTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/CodeSystemUtilTest.java
@@ -17,7 +17,8 @@ public class CodeSystemUtilTest {
             Arguments.of("http://snomed.info/sct", "2.16.840.1.113883.2.1.3.2.4.15"),
             Arguments.of("https://fhir.hl7.org.uk/Id/egton-codes", "2.16.840.1.113883.2.1.6.3"),
             Arguments.of("http://read.info/readv2", "2.16.840.1.113883.2.1.6.2"),
-            Arguments.of("http://read.info/ctv3", "2.16.840.1.113883.2.1.3.2.4.14")
+            Arguments.of("http://read.info/ctv3", "2.16.840.1.113883.2.1.3.2.4.14"),
+            Arguments.of("https://fhir.hl7.org.uk/Id/emis-drug-codes", "2.16.840.1.113883.2.1.6.9")
         );
     }
 
@@ -30,9 +31,9 @@ public class CodeSystemUtilTest {
     }
 
     @Test
-    void When_FhirCodeSystemIsUnknown_Expect_FhirCodeSystemIsProvided() {
+    void When_FhirCodeSystemIsUnknown_Expect_EmptyString() {
         var hl7Code = CodeSystemsUtil.getHl7code("https://unknown.code/system");
 
-        assertThat(hl7Code).isEqualTo("https://unknown.code/system");
+        assertThat(hl7Code).isEmpty();
     }
 }

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/CodeSystemUtilTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/utils/CodeSystemUtilTest.java
@@ -10,8 +10,7 @@ import uk.nhs.adaptors.gp2gp.ehr.utils.CodeSystemsUtil;
 
 import java.util.stream.Stream;
 
-public class CodeSystemUtilTest {
-
+class CodeSystemUtilTest {
     private static Stream<Arguments> knownCodeSystems() {
         return Stream.of(
             Arguments.of("http://snomed.info/sct", "2.16.840.1.113883.2.1.3.2.4.15"),

--- a/service/src/test/resources/ehr/mapper/blood_pressure/blood-pressure-with-codeable-concepts.xml
+++ b/service/src/test/resources/ehr/mapper/blood_pressure/blood-pressure-with-codeable-concepts.xml
@@ -2,8 +2,8 @@
     <CompoundStatement classCode="BATTERY" moodCode="EVN">
         <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
         <code code="852471000000107" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Prothrombin time">
-            <translation code="42Q5.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Prothrombin time" />
             <originalText>Prothrombin time</originalText>
+            <translation code="42Q5.00" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Prothrombin time" />
         </code>
         <statusCode code="COMPLETE"/>
         <effectiveTime>
@@ -14,8 +14,8 @@
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
                 <code code="72313002" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Systolic arterial pressure">
-                    <translation code="2469" codeSystem="2.16.840.1.113883.2.1.6.3" displayName="Systolic arterial pressure" />
                     <originalText>Systolic arterial pressure</originalText>
+                    <translation code="2469" codeSystem="2.16.840.1.113883.2.1.6.3" displayName="Systolic arterial pressure" />
                 </code>
                 <statusCode code="COMPLETE"/>
                 <effectiveTime>
@@ -36,8 +36,8 @@
             <ObservationStatement classCode="OBS" moodCode="EVN">
                 <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
                 <code code="1091811000000102" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Diastolic arterial pressure">
-                    <translation code="246A" codeSystem="2.16.840.1.113883.2.1.6.3" displayName="Diastolic arterial pressure" />
                     <originalText>Diastolic arterial pressure</originalText>
+                    <translation code="246A" codeSystem="2.16.840.1.113883.2.1.6.3" displayName="Diastolic arterial pressure" />
                 </code>
                 <statusCode code="COMPLETE"/>
                 <effectiveTime>

--- a/service/src/test/resources/ehr/mapper/codeableconcept/allergyActive/allergy_with_snomed_and_non_snomed_codes_in_coding_with_text.xml
+++ b/service/src/test/resources/ehr/mapper/codeableconcept/allergyActive/allergy_with_snomed_and_non_snomed_codes_in_coding_with_text.xml
@@ -1,5 +1,5 @@
 <code code="292971006" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Pivampicillin adverse reaction pt">
+    <originalText>Pivampicillin adverse reaction (rt)</originalText>
     <translation code="TJ00800" codeSystem="2.16.840.1.113883.2.1.6.2" displayName="Adverse reaction to pivampicillin pt" />
     <translation code="TJ00800-1" codeSystem="2.16.840.1.113883.2.1.3.2.4.14" displayName="Adverse reaction to pivampicillin" />
-    <originalText>Pivampicillin adverse reaction (rt)</originalText>
 </code>

--- a/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP3.json
+++ b/wiremock/stubs/__files/EMISPatientStructurede2eResponsePWTP3.json
@@ -8817,7 +8817,7 @@
                     "coding": [
                         {
                             "system": "https://fhir.hl7.org.uk/Id/emis-drug-codes",
-                            "code": "CO2 27587NEMIS",
+                            "code": "CO227587NEMIS",
                             "display": "Coloplast Micro-bag two piece ostomy system urostomy bag 14204 40mm (Coloplast Ltd)",
                             "userSelected": true
                         },


### PR DESCRIPTION
## What

* Update CD template to ensure that `originalText` is always populated first.
* Update tests to reflect the ordering change
* Update `CodeableConceptCdMapper` to only add code translations when it is possible to map from URL to OID as anything other than an OID is not supported in the schema.
* Update CodesSystemsUtil to return empty string if a mapping to known code system cannot be found.
* Update test accordingly.
* Update `CodeableConceptCdMapper` to create a new coding element for legacy codes, to avoid modifying an element whilst iterating a list.
* Add test for an unknown code system.
* SonarCube fix to remove public modifier on test class.
* Fix error in "Medications" test file, where a legacy code contains a space, which is not valid according to the schema.

## Why

The imports were failing on EMIS due to schema validation issues, looking at the schema:

```xml
   <xsd:complexContent>
            <xsd:extension base="ANY">
                <xsd:sequence>
                    <xsd:element name="originalText" type="ED" minOccurs="0">
                        <xsd:annotation>
                            <xsd:documentation> The text or phrase used as the basis for the coding. </xsd:documentation>
                            <xsd:appinfo />
                        </xsd:annotation>
                    </xsd:element>
                    <xsd:element name="qualifier" type="CR" minOccurs="0" maxOccurs="unbounded">
                        <xsd:annotation>
                            <xsd:documentation> Specifies additional codes that increase the
                                specificity of the primary code. </xsd:documentation>
                            <xsd:appinfo />
                        </xsd:annotation>
                    </xsd:element>
                    <xsd:element name="group" minOccurs="0" maxOccurs="unbounded">
                        <xsd:complexType>
                            <xsd:sequence>
                                <xsd:element name="qualifier" type="CR" maxOccurs="unbounded" />
                            </xsd:sequence>
                        </xsd:complexType>
                    </xsd:element>
                    <xsd:element name="translation" type="CD" minOccurs="0" maxOccurs="unbounded">
                        <xsd:annotation>
                            <xsd:documentation> A set of other concept descriptors that translate
                                this concept descriptor into other code systems. </xsd:documentation>
                            <xsd:appinfo />
                        </xsd:annotation>
                    </xsd:element>
                </xsd:sequence>
...
```
It appears that the `originalText` field should be appearing first in the sequence ahead of the translations.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
