### PR TITLE
NIAD-3153, -3154: putting the reverted changes for NIAD-3153 and NIAD-3154 back in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ In the case that neither of these are present, the existing behavior of using th
 ### Added
 
 * GP2GP Adaptor now populates the PlanStatement / confidentialityCode field when the ProcedureRequest.meta.security field contains NOPAT
-* When the ReferralRequest.meta.security field contains NOPAT, the GP2GP Adaptor will now populate the RequestStatement / confidentialityCode field accordingly.
-* The GP2GP Adaptor now populates the CompoundStatement / confidentialityCode field when Observation.meta.security field contains NOPAT
 
 ## [2.2.2] - 2025-02-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+* When the ReferralRequest.meta.security field contains NOPAT, the GP2GP Adaptor will now populate the RequestStatement / confidentialityCode field accordingly.
+* The GP2GP Adaptor now populates the CompoundStatement / confidentialityCode field when Observation.meta.security field contains NOPAT
+
 ## [2.3.0] - 2025-03-24
 
 ### Fixed

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapper.java
@@ -62,8 +62,6 @@ public class BloodPressureMapper {
 
     public String mapBloodPressure(Observation observation, boolean isNested) {
 
-        var confidentialityCode = confidentialityService.generateConfidentialityCode(observation);
-
         BloodPressureParametersBuilder builder = BloodPressureParameters.builder()
             .isNested(isNested)
             .id(messageContext.getIdMapper().getOrNew(ResourceType.Observation, observation.getIdElement()))

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapper.java
@@ -62,11 +62,14 @@ public class BloodPressureMapper {
 
     public String mapBloodPressure(Observation observation, boolean isNested) {
 
+        var confidentialityCode = confidentialityService.generateConfidentialityCode(observation);
+
         BloodPressureParametersBuilder builder = BloodPressureParameters.builder()
             .isNested(isNested)
             .id(messageContext.getIdMapper().getOrNew(ResourceType.Observation, observation.getIdElement()))
             .effectiveTime(prepareEffectiveTimeForObservation(observation))
             .availabilityTime(prepareAvailabilityTimeForObservation(observation))
+            .confidentialityCode(confidentialityCode.orElse(null))
             .compoundStatementCode(buildBloodPressureCode(observation));
 
         extractBloodPressureComponent(observation, SYSTOLIC_CODE).ifPresent(observationComponent -> {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapper.java
@@ -69,7 +69,6 @@ public class BloodPressureMapper {
             .id(messageContext.getIdMapper().getOrNew(ResourceType.Observation, observation.getIdElement()))
             .effectiveTime(prepareEffectiveTimeForObservation(observation))
             .availabilityTime(prepareAvailabilityTimeForObservation(observation))
-            .confidentialityCode(confidentialityCode.orElse(null))
             .compoundStatementCode(buildBloodPressureCode(observation));
 
         extractBloodPressureComponent(observation, SYSTOLIC_CODE).ifPresent(observationComponent -> {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapper.java
@@ -110,7 +110,6 @@ public class RequestStatementMapper {
                 .requestStatementId(idMapper.getOrNew(ResourceType.ReferralRequest, referralRequest.getIdElement()))
                 .isNested(isNested)
                 .availabilityTime(StatementTimeMappingUtils.prepareAvailabilityTime(referralRequest.getAuthoredOnElement()))
-                .confidentialityCode(confidentialityCode.orElse(null))
                 .text(buildTextDescription())
                 .priorityCode(buildPriorityCode())
                 .code(buildCode());

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapper.java
@@ -103,8 +103,6 @@ public class RequestStatementMapper {
                 processAgent(agentRef, onBehalfOf);
             }
 
-            var confidentialityCode = confidentialityService.generateConfidentialityCode(referralRequest);
-
             final IdMapper idMapper = messageContext.getIdMapper();
             templateParameters
                 .requestStatementId(idMapper.getOrNew(ResourceType.ReferralRequest, referralRequest.getIdElement()))

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapper.java
@@ -103,11 +103,14 @@ public class RequestStatementMapper {
                 processAgent(agentRef, onBehalfOf);
             }
 
+            var confidentialityCode = confidentialityService.generateConfidentialityCode(referralRequest);
+
             final IdMapper idMapper = messageContext.getIdMapper();
             templateParameters
                 .requestStatementId(idMapper.getOrNew(ResourceType.ReferralRequest, referralRequest.getIdElement()))
                 .isNested(isNested)
                 .availabilityTime(StatementTimeMappingUtils.prepareAvailabilityTime(referralRequest.getAuthoredOnElement()))
+                .confidentialityCode(confidentialityCode.orElse(null))
                 .text(buildTextDescription())
                 .priorityCode(buildPriorityCode())
                 .code(buildCode());

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/BloodPressureParameters.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/BloodPressureParameters.java
@@ -23,5 +23,4 @@ public class BloodPressureParameters {
     private String systolicCode;
     private String diastolicCode;
     private String participant;
-    private String confidentialityCode;
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/BloodPressureParameters.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/BloodPressureParameters.java
@@ -23,4 +23,5 @@ public class BloodPressureParameters {
     private String systolicCode;
     private String diastolicCode;
     private String participant;
+    private String confidentialityCode;
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/RequestStatementTemplateParameters.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/RequestStatementTemplateParameters.java
@@ -17,5 +17,4 @@ public class RequestStatementTemplateParameters {
     private String participant;
     private String responsibleParty;
     private String text;
-    private String confidentialityCode;
 }

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/RequestStatementTemplateParameters.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/RequestStatementTemplateParameters.java
@@ -17,4 +17,5 @@ public class RequestStatementTemplateParameters {
     private String participant;
     private String responsibleParty;
     private String text;
+    private String confidentialityCode;
 }

--- a/service/src/main/resources/templates/ehr_compound_statement_blood_pressure_template.mustache
+++ b/service/src/main/resources/templates/ehr_compound_statement_blood_pressure_template.mustache
@@ -7,6 +7,9 @@
             {{{effectiveTime}}}
         </effectiveTime>
         {{{availabilityTime}}}
+        {{#confidentialityCode}}
+            {{{confidentialityCode}}}
+        {{/confidentialityCode}}
         {{#systolicId}}
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">

--- a/service/src/main/resources/templates/ehr_compound_statement_blood_pressure_template.mustache
+++ b/service/src/main/resources/templates/ehr_compound_statement_blood_pressure_template.mustache
@@ -7,9 +7,6 @@
             {{{effectiveTime}}}
         </effectiveTime>
         {{{availabilityTime}}}
-        {{#confidentialityCode}}
-            {{{confidentialityCode}}}
-        {{/confidentialityCode}}
         {{#systolicId}}
         <component typeCode="COMP" contextConductionInd="true">
             <ObservationStatement classCode="OBS" moodCode="EVN">

--- a/service/src/main/resources/templates/ehr_request_statement_template.mustache
+++ b/service/src/main/resources/templates/ehr_request_statement_template.mustache
@@ -10,6 +10,9 @@
             <center nullFlavor="NI"/>
         </effectiveTime>
         {{{availabilityTime}}}
+        {{#confidentialityCode}}
+            {{{confidentialityCode}}}
+        {{/confidentialityCode}}
         {{#priorityCode}}
         {{{priorityCode}}}
         {{/priorityCode}}

--- a/service/src/main/resources/templates/ehr_request_statement_template.mustache
+++ b/service/src/main/resources/templates/ehr_request_statement_template.mustache
@@ -10,9 +10,6 @@
             <center nullFlavor="NI"/>
         </effectiveTime>
         {{{availabilityTime}}}
-        {{#confidentialityCode}}
-            {{{confidentialityCode}}}
-        {{/confidentialityCode}}
         {{#priorityCode}}
         {{{priorityCode}}}
         {{/priorityCode}}

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapperTest.java
@@ -5,7 +5,6 @@ import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -95,7 +94,7 @@ public class BloodPressureMapperTest {
         messageContext.resetMessageContext();
     }
 
-    @Disabled
+
     @Test
     public void When_MappingBloodPressureWithNopat_Expect_CompoundStatementWithConfidentialityCode() {
         when(mockCodeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(any(CodeableConcept.class)))

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/BloodPressureMapperTest.java
@@ -5,6 +5,7 @@ import org.hl7.fhir.dstu3.model.CodeableConcept;
 import org.hl7.fhir.dstu3.model.Observation;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -94,6 +95,7 @@ public class BloodPressureMapperTest {
         messageContext.resetMessageContext();
     }
 
+    @Disabled
     @Test
     public void When_MappingBloodPressureWithNopat_Expect_CompoundStatementWithConfidentialityCode() {
         when(mockCodeableConceptCdMapper.mapCodeableConceptToCdForBloodPressure(any(CodeableConcept.class)))

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapperTest.java
@@ -18,7 +18,6 @@ import org.hl7.fhir.dstu3.model.ReferralRequest;
 import org.hl7.fhir.dstu3.model.ResourceType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -360,7 +359,6 @@ public class RequestStatementMapperTest {
         assertThat(outputMessage).isEqualTo(expectedOutputMessage);
     }
 
-    @Disabled
     @Test
     public void When_MappingReferralRequestWithNoPat_Expect_RequestStatementWithConfidentialityCode() {
         when(confidentialityService.generateConfidentialityCode(any(ReferralRequest.class)))

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapperTest.java
@@ -18,6 +18,7 @@ import org.hl7.fhir.dstu3.model.ReferralRequest;
 import org.hl7.fhir.dstu3.model.ResourceType;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -359,6 +360,7 @@ public class RequestStatementMapperTest {
         assertThat(outputMessage).isEqualTo(expectedOutputMessage);
     }
 
+    @Disabled
     @Test
     public void When_MappingReferralRequestWithNoPat_Expect_RequestStatementWithConfidentialityCode() {
         when(confidentialityService.generateConfidentialityCode(any(ReferralRequest.class)))


### PR DESCRIPTION
## What

Putting the reverted changes for NIAD-3153 and NIAD-3154 back in place

## Why

The reverted changes were just temporarily removed to make the next release to come through and now the original changes are being put back into their place

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
