### PR TITLE
NIAD-3155: Send over Observation (Narrative).meta.security NOPAT field to incumbent

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapper.java
@@ -255,32 +255,32 @@ public class EncounterComponentsMapper {
             resource.getIdElement().getIdPart()));
     }
 
-    private Optional<String> mapAllergyIntolerance(Resource resource) {
+    protected Optional<String> mapAllergyIntolerance(Resource resource) {
         return Optional.of(allergyStructureMapper.mapAllergyIntoleranceToAllergyStructure((AllergyIntolerance) resource));
     }
 
-    private Optional<String> mapCondition(Resource resource) {
+    protected Optional<String> mapCondition(Resource resource) {
         return Optional.of(conditionLinkSetMapper.mapConditionToLinkSet((Condition) resource, IS_NESTED));
     }
 
-    private Optional<String> mapDocumentReference(Resource resource) {
+    protected Optional<String> mapDocumentReference(Resource resource) {
         return Optional.of(
             documentReferenceToNarrativeStatementMapper.mapDocumentReferenceToNarrativeStatement((DocumentReference) resource));
     }
 
-    private Optional<String> mapImmunization(Resource resource) {
+    protected Optional<String> mapImmunization(Resource resource) {
         return Optional.of(
             immunizationObservationStatementMapper.mapImmunizationToObservationStatement((Immunization) resource, IS_NESTED));
     }
 
-    private Optional<String> mapMedicationRequest(Resource resource) {
+    protected Optional<String> mapMedicationRequest(Resource resource) {
         return Optional.of(resource)
             .map(MedicationRequest.class::cast)
             .filter(not(MedicationRequestUtils::isStoppedMedicationOrder))
             .map(medicationStatementMapper::mapMedicationRequestToMedicationStatement);
     }
 
-    private Optional<String> mapObservation(Resource resource) {
+    protected Optional<String> mapObservation(Resource resource) {
         Observation observation = (Observation) resource;
         if (CodeableConceptMappingUtils.hasCode(observation.getCode(), List.of(NARRATIVE_STATEMENT_CODE))) {
             return Optional.of(observationToNarrativeStatementMapper.mapObservationToNarrativeStatement(observation, IS_NESTED));
@@ -292,17 +292,17 @@ public class EncounterComponentsMapper {
         return Optional.of(observationStatementMapper.mapObservationToObservationStatement(observation, IS_NESTED));
     }
 
-    private Optional<String> mapProcedureRequest(Resource resource) {
+    protected Optional<String> mapProcedureRequest(Resource resource) {
         return Optional.ofNullable(
             diaryPlanStatementMapper.mapProcedureRequestToPlanStatement((ProcedureRequest) resource, IS_NESTED)
         );
     }
 
-    private Optional<String> mapReferralRequest(Resource resource) {
+    protected Optional<String> mapReferralRequest(Resource resource) {
         return Optional.of(requestStatementMapper.mapReferralRequestToRequestStatement((ReferralRequest) resource, IS_NESTED));
     }
 
-    private Optional<String> mapDiagnosticReport(Resource resource) {
+    protected Optional<String> mapDiagnosticReport(Resource resource) {
         return Optional.of(diagnosticReportMapper.mapDiagnosticReportToCompoundStatement((DiagnosticReport) resource));
     }
 

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationToNarrativeStatementMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationToNarrativeStatementMapper.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import com.github.mustachejava.Mustache;
 
 import lombok.RequiredArgsConstructor;
+import uk.nhs.adaptors.gp2gp.common.service.ConfidentialityService;
 import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
 import uk.nhs.adaptors.gp2gp.ehr.mapper.parameters.NarrativeStatementTemplateParameters;
 import uk.nhs.adaptors.gp2gp.ehr.utils.DateFormatUtil;
@@ -24,12 +25,17 @@ public class ObservationToNarrativeStatementMapper {
 
     private final MessageContext messageContext;
     private final ParticipantMapper participantMapper;
+    private final ConfidentialityService confidentialityService;
 
     public String mapObservationToNarrativeStatement(Observation observation, boolean isNested) {
+
+        var confidentialityCode = confidentialityService.generateConfidentialityCode(observation);
+
         final IdMapper idMapper = messageContext.getIdMapper();
         var narrativeStatementTemplateParameters = NarrativeStatementTemplateParameters.builder()
             .narrativeStatementId(idMapper.getOrNew(ResourceType.Observation, observation.getIdElement()))
             .availabilityTime(getAvailabilityTime(observation))
+            .confidentialityCode(confidentialityCode.orElse(null))
             .comment(observation.getComment())
             .isNested(isNested);
 

--- a/service/src/main/resources/templates/ehr_narrative_statement_template.mustache
+++ b/service/src/main/resources/templates/ehr_narrative_statement_template.mustache
@@ -4,6 +4,9 @@
         <text>{{comment}}</text>
         <statusCode code="COMPLETE" />
         <availabilityTime value="{{availabilityTime}}" />
+        {{#confidentialityCode}}
+            {{{confidentialityCode}}}
+        {{/confidentialityCode}}
         {{#participant}}
         {{{.}}}
         {{/participant}}

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
@@ -179,7 +179,7 @@ public class EhrExtractMapperComponentTest {
                 randomIdGeneratorService,
                 confidentialityService
             ),
-            new ObservationToNarrativeStatementMapper(messageContext, participantMapper),
+            new ObservationToNarrativeStatementMapper(messageContext, participantMapper, confidentialityService),
             new ObservationStatementMapper(
                 messageContext,
                 new StructuredObservationValueMapper(),

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
@@ -7,6 +7,7 @@ import org.hl7.fhir.dstu3.model.Encounter;
 import org.hl7.fhir.dstu3.model.IdType;
 import org.hl7.fhir.dstu3.model.QuestionnaireResponse;
 import org.hl7.fhir.dstu3.model.Reference;
+import org.hl7.fhir.dstu3.model.Resource;
 import org.hl7.fhir.dstu3.model.ResourceType;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
@@ -83,6 +84,15 @@ public class EncounterComponentsMapperTest {
         + "expected-components-17-topic-no-categories.xml";
     private static final String CONTAINED_TEST_DIRECTORY = TEST_DIRECTORY + "contained-resources/";
 
+    private static final String AGENT_DIRECTORY_FOLDER = "/ehr/mapper/observation/";
+    private static final String INPUT_AGENT_DIRECTORY = AGENT_DIRECTORY_FOLDER + "observation-of-narrative-type-with-nopat.json";
+    private static final String CONFIDENTIALITY_CODE = """
+        <confidentialityCode
+            code="NOPAT"
+            codeSystem="2.16.840.1.113883.4.642.3.47"
+            displayName="no disclosure to patient, family or caregivers without attending provider's authorization"
+        />""";
+
     @Mock
     private RandomIdGeneratorService randomIdGeneratorService;
     @Mock
@@ -96,6 +106,7 @@ public class EncounterComponentsMapperTest {
 
     private EncounterComponentsMapper encounterComponentsMapper;
     private MessageContext messageContext;
+    private static final FhirParseService FHIR_PARSE_SERVICE = new FhirParseService();
 
     @BeforeEach
     public void setUp() {
@@ -165,7 +176,7 @@ public class EncounterComponentsMapperTest {
             confidentialityService
         );
         ObservationToNarrativeStatementMapper observationToNarrativeStatementMapper =
-            new ObservationToNarrativeStatementMapper(messageContext, participantMapper);
+            new ObservationToNarrativeStatementMapper(messageContext, participantMapper, confidentialityService);
         SpecimenMapper specimenMapper = getSpecimenMapper(structuredObservationValueMapper, participantMapper);
 
         ObservationStatementMapper observationStatementMapper = new ObservationStatementMapper(
@@ -216,6 +227,19 @@ public class EncounterComponentsMapperTest {
     @AfterEach
     public void tearDown() {
         messageContext.resetMessageContext();
+    }
+
+    @Test
+    public void testObservationWithNOPATGetsTranslatedIntoNarrativeWithConfidentialityCode() {
+        var jsonInput = ResourceTestFileUtils.getFileContent(INPUT_AGENT_DIRECTORY);
+        Bundle bundle = FHIR_PARSE_SERVICE.parseResource(jsonInput, Bundle.class);
+        Resource observation = bundle.getEntry().get(1).getResource();
+
+        when(confidentialityService.generateConfidentialityCode(observation)).thenReturn(Optional.of(CONFIDENTIALITY_CODE));
+
+        var result = encounterComponentsMapper.mapObservation(observation);
+
+        assertThat(result.get()).contains(CONFIDENTIALITY_CODE);
     }
 
     @Test

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationToNarrativeStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationToNarrativeStatementMapperTest.java
@@ -28,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import uk.nhs.adaptors.gp2gp.common.service.ConfidentialityService;
 import uk.nhs.adaptors.gp2gp.common.service.FhirParseService;
 import uk.nhs.adaptors.gp2gp.common.service.RandomIdGeneratorService;
 import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
@@ -60,6 +61,9 @@ public class ObservationToNarrativeStatementMapperTest {
     @Mock
     private RandomIdGeneratorService randomIdGeneratorService;
 
+    @Mock
+    private ConfidentialityService confidentialityService;
+
     private CharSequence expectedOutputMessage;
     private ObservationToNarrativeStatementMapper observationToNarrativeStatementMapper;
     private MessageContext messageContext;
@@ -71,7 +75,9 @@ public class ObservationToNarrativeStatementMapperTest {
 
         messageContext = new MessageContext(randomIdGeneratorService);
         messageContext.initialize(new Bundle());
-        observationToNarrativeStatementMapper = new ObservationToNarrativeStatementMapper(messageContext, new ParticipantMapper());
+        observationToNarrativeStatementMapper = new ObservationToNarrativeStatementMapper(messageContext,
+                                                                                          new ParticipantMapper(),
+                                                                                          confidentialityService);
     }
 
     @AfterEach

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
@@ -199,7 +199,7 @@ public class EhrExtractUATTest {
                 randomIdGeneratorService,
                 confidentialityService
             ),
-            new ObservationToNarrativeStatementMapper(messageContext, participantMapper),
+            new ObservationToNarrativeStatementMapper(messageContext, participantMapper, confidentialityService),
             new ObservationStatementMapper(
                 messageContext,
                 new StructuredObservationValueMapper(),

--- a/service/src/test/resources/ehr/mapper/observation/observation-of-narrative-type-with-nopat.json
+++ b/service/src/test/resources/ehr/mapper/observation/observation-of-narrative-type-with-nopat.json
@@ -1,0 +1,244 @@
+{
+    "resourceType": "Bundle",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/GPConnect-StructuredRecord-Bundle-1"
+        ]
+    },
+    "type": "collection",
+    "entry": [
+        {
+            "resource": {
+                "resourceType": "Patient",
+                "id": "88F14BF6-CADE-47D6-90E2-B10519BF956F",
+                "meta": {
+                    "versionId": "5852021019724084706",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Patient-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/nhs-number",
+                        "value": "9465701459"
+                    }
+                ],
+                "name": [
+                    {
+                        "use": "official",
+                        "family": "Nel",
+                        "given": [
+                            "Morris",
+                            "Chad"
+                        ],
+                        "prefix": [
+                            "Mr"
+                        ]
+                    }
+                ],
+                "gender": "male",
+                "birthDate": "1999-02-25",
+                "generalPractitioner": [
+                    {
+                        "reference": "Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+                    }
+                ],
+                "managingOrganization": {
+                    "reference": "Organization/5E496953-065B-41F2-9577-BE8F2FBD0757"
+                }
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Observation",
+                "id": "9BEFB146-B729-4EB8-908C-539B279FFEB5",
+                "meta": {
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Observation-1"
+                    ]
+                },
+                "identifier": [
+                    {
+                        "system": "https://EMISWeb/A82038",
+                        "value": "9BEFB146-B729-4EB8-908C-539B279FFEB5"
+                    }
+                ],
+                "status": "final",
+                "code": {
+                    "coding": [
+                        {
+                            "system": "http://read.info/readv2",
+                            "code": "246..00",
+                            "display": "O/E - blood pressure reading",
+                            "userSelected": true
+                        },
+                        {
+                            "extension": [
+                                {
+                                    "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                    "extension": [
+                                        {
+                                            "url": "descriptionId",
+                                            "valueId": "254063019"
+                                        },
+                                        {
+                                            "url": "descriptionDisplay",
+                                            "valueString": "O/E - blood pressure reading"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "system": "http://snomed.info/sct",
+                            "code": "37331000000100",
+                            "display": "O/E - blood pressure reading"
+                        }
+                    ]
+                },
+                "subject": {
+                    "reference": "Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+                },
+                "context": {
+                    "reference": "Encounter/4088F3A1-CE58-4374-AABA-763C31738281"
+                },
+                "effectiveDateTime": "2010-07-14T17:55:00+01:00",
+                "issued": "2010-07-14T16:28:13.577+01:00",
+                "comment": "This is the BP reading in a consultation with a note",
+                "component": [
+                    {
+                        "code": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.hl7.org.uk/Id/egton-codes",
+                                    "code": "2469",
+                                    "display": "Systolic blood pressure",
+                                    "userSelected": true
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                            "extension": [
+                                                {
+                                                    "url": "descriptionId",
+                                                    "valueId": "120159016"
+                                                },
+                                                {
+                                                    "url": "descriptionDisplay",
+                                                    "valueString": "Systolic arterial pressure"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "system": "http://snomed.info/sct",
+                                    "code": "72313002",
+                                    "display": "Systolic arterial pressure"
+                                }
+                            ]
+                        },
+                        "valueQuantity": {
+                            "value": 120,
+                            "unit": "mmHg"
+                        }
+                    },
+                    {
+                        "code": {
+                            "coding": [
+                                {
+                                    "system": "https://fhir.hl7.org.uk/Id/egton-codes",
+                                    "code": "246A",
+                                    "display": "Diastolic blood pressure",
+                                    "userSelected": true
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-coding-sctdescid",
+                                            "extension": [
+                                                {
+                                                    "url": "descriptionId",
+                                                    "valueId": "2734671000000117"
+                                                },
+                                                {
+                                                    "url": "descriptionDisplay",
+                                                    "valueString": "Diastolic arterial pressure"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "system": "http://snomed.info/sct",
+                                    "code": "1091811000000102",
+                                    "display": "Diastolic arterial pressure"
+                                }
+                            ]
+                        },
+                        "valueQuantity": {
+                            "value": 75,
+                            "unit": "mmHg"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "resource": {
+                "resourceType": "Organization",
+                "id": "5E496953-065B-41F2-9577-BE8F2FBD0757",
+                "meta": {
+                    "versionId": "1112974926854455048",
+                    "profile": [
+                        "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Organization-1"
+                    ]
+                },
+                "extension": [
+                    {
+                        "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MainLocation-1",
+                        "valueReference": {
+                            "reference": "Location/EB3994A6-5A87-4B53-A414-913137072F57"
+                        }
+                    }
+                ],
+                "identifier": [
+                    {
+                        "system": "https://fhir.nhs.uk/Id/ods-organization-code",
+                        "value": "A82038"
+                    }
+                ],
+                "type": [
+                    {
+                        "coding": [
+                            {
+                                "system": "https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-OrganisationType-1",
+                                "code": "gp-practice"
+                            }
+                        ],
+                        "text": "GP Practice"
+                    }
+                ],
+                "name": "TEMPLE SOWERBY MEDICAL PRACTICE",
+                "telecom": [
+                    {
+                        "system": "phone",
+                        "value": "01133800000",
+                        "use": "work",
+                        "rank": 1
+                    }
+                ],
+                "address": [
+                    {
+                        "use": "work",
+                        "type": "physical",
+                        "line": [
+                            "Fulford Grange",
+                            "Micklefield Lane",
+                            "Rawdon",
+                            "Rawdon"
+                        ],
+                        "city": "Leeds",
+                        "district": "Yorkshire",
+                        "postalCode": "LS19 6BA"
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## What

Observation with NOPAT get translated into narrative with confidentialityCode

## Why

The changes are made to make the adaptor Redactions compliant

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
