### PR TITLE
Code Improvement: Disable access to external entities in XML parsing.

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/service/XPathService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/service/XPathService.java
@@ -25,7 +25,7 @@ import lombok.SneakyThrows;
 @Component
 public class XPathService {
     public Document parseDocumentFromXml(String xml) throws SAXException {
-        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newDefaultInstance();
         InputSource inputSource;
         DocumentBuilder documentBuilder;
         try {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/StructuredRecordMappingService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/StructuredRecordMappingService.java
@@ -174,7 +174,7 @@ public class StructuredRecordMappingService {
     }
 
     private static String toString(Document document) throws TransformerException {
-        TransformerFactory tf = TransformerFactory.newInstance();
+        TransformerFactory tf = TransformerFactory.newDefaultInstance();
         Transformer transformer = tf.newTransformer();
         StringWriter writer = new StringWriter();
 


### PR DESCRIPTION
## What

* Update from `.newInstance()` to `.newDefaultInstance()` on `DocumentBuilderFactory` and `TransformerFactory` which should add the flags for critical security risks.

## Why

![image](https://github.com/user-attachments/assets/1c536ce2-5cb3-4e4f-bebb-4cefff276914)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

