### PR TITLE
NIAD-3156: Send over Encounter.meta.security NOPAT field to incumbent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+The GP2GP Adaptor now adds the EhrComposition / confidentialityCode field when Encounter.meta.security contains NOPAT security entry
+
+
 ## [2.4.0] - 2025-04-02
 
 ### Added

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterMapper.java
@@ -27,6 +27,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import uk.nhs.adaptors.gp2gp.common.service.ConfidentialityService;
 import uk.nhs.adaptors.gp2gp.ehr.exception.EhrMapperException;
 import uk.nhs.adaptors.gp2gp.ehr.mapper.parameters.EncounterTemplateParameters;
 import uk.nhs.adaptors.gp2gp.ehr.utils.DateFormatUtil;
@@ -48,6 +49,7 @@ public class EncounterMapper {
 
     private final MessageContext messageContext;
     private final EncounterComponentsMapper encounterComponentsMapper;
+    private final ConfidentialityService confidentialityService;
 
     public String mapEncounterToEhrComposition(Encounter encounter) {
         LOGGER.debug("Generating ehrComposition for Encounter {}", encounter.getId());
@@ -59,6 +61,8 @@ public class EncounterMapper {
             return StringUtils.EMPTY;
         }
 
+        var confidentialityCode = confidentialityService.generateConfidentialityCode(encounter);
+
         final IdMapper idMapper = messageContext.getIdMapper();
         AgentDirectory agentDirectory = messageContext.getAgentDirectory();
 
@@ -66,6 +70,7 @@ public class EncounterMapper {
             .encounterStatementId(idMapper.getOrNew(ResourceType.Encounter, encounter.getIdElement()))
             .effectiveTime(StatementTimeMappingUtils.prepareEffectiveTimeForEncounter(encounter))
             .availabilityTime(StatementTimeMappingUtils.prepareAvailabilityTime(encounter.getPeriod().getStartElement()))
+            .confidentialityCode(confidentialityCode.orElse(null))
             .status(COMPLETE_CODE)
             .components(components)
             .code(buildCode(encounter))

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/EncounterTemplateParameters.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/EncounterTemplateParameters.java
@@ -21,4 +21,5 @@ public class EncounterTemplateParameters {
     private String participant2;
     private String author;
     private String locationName;
+    private String confidentialityCode;
 }

--- a/service/src/main/resources/templates/ehr_encounter_to_ehr_composition_template.mustache
+++ b/service/src/main/resources/templates/ehr_encounter_to_ehr_composition_template.mustache
@@ -14,6 +14,9 @@
             {{{effectiveTime}}}
         </effectiveTime>
         {{{availabilityTime}}}
+        {{#confidentialityCode}}
+            {{{confidentialityCode}}}
+        {{/confidentialityCode}}
         <author typeCode="AUT" contextControlCode="OP">
             <time {{#authorTime}}value="{{authorTime}}"{{/authorTime}}{{^authorTime}}nullFlavor="UNK"{{/authorTime}} />
             <agentRef classCode="AGNT">

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
@@ -208,7 +208,7 @@ public class EhrExtractMapperComponentTest {
 
         ehrExtractMapper = new EhrExtractMapper(randomIdGeneratorService,
             timestampService,
-            new EncounterMapper(messageContext, encounterComponentsMapper),
+            new EncounterMapper(messageContext, encounterComponentsMapper, confidentialityService),
             nonConsultationResourceMapper,
             agentDirectoryMapper,
             messageContext);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
@@ -152,7 +152,7 @@ public class EhrExtractUATTest {
             = new AgentPersonMapper(messageContext);
         final AgentDirectoryMapper agentDirectoryMapper = new AgentDirectoryMapper(messageContext, agentPersonMapper);
 
-        final EncounterMapper encounterMapper = new EncounterMapper(messageContext, encounterComponentsMapper);
+        final EncounterMapper encounterMapper = new EncounterMapper(messageContext, encounterComponentsMapper, confidentialityService);
 
         final NonConsultationResourceMapper nonConsultationResourceMapper =
             new NonConsultationResourceMapper(messageContext, randomIdGeneratorService, encounterComponentsMapper,

--- a/service/src/test/resources/ehr/mapper/encounter/input-encounter-with-nopat.json
+++ b/service/src/test/resources/ehr/mapper/encounter/input-encounter-with-nopat.json
@@ -1,0 +1,83 @@
+{
+  "resourceType":"Encounter",
+  "id":"F550CC56-EF65-4934-A7B1-3DC2E02243C3",
+  "meta": {
+    "profile": [
+      "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Immunization-1"
+    ],
+    "security": [{
+      "system":"http://hl7.org/fhir/v3/ActCode",
+      "code":"NOPAT",
+      "display":"no disclosure to patient, family or caregivers without attending provider's authorization"
+    }]
+  },
+  "identifier":[
+    {
+      "system":"https://EMISWeb/A82038",
+      "value":"F550CC56-EF65-4934-A7B1-3DC2E02243C3"
+    }
+  ],
+  "status":"finished",
+  "type":[
+    {
+      "text":"GP Surgery",
+      "coding": [
+        {
+          "system":"http://snomed.info/sct",
+          "code":"24671000000101",
+          "display":"Telephone call to a patient"
+        }
+      ]
+    }
+  ],
+  "subject":{
+    "reference":"Patient/88F14BF6-CADE-47D6-90E2-B10519BF956F"
+  },
+  "participant":[
+    {
+      "type":[
+        {
+          "coding":[
+            {
+              "system":"http://hl7.org/fhir/v3/ParticipationType",
+              "code":"PPRF",
+              "display":"primary performer"
+            }
+          ]
+        }
+      ],
+      "individual":{
+        "reference":"Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+      }
+    },
+    {
+      "type":[
+        {
+          "coding":[
+            {
+              "system":"https://fhir.nhs.uk/STU3/CodeSystem/GPConnect-ParticipantType-1",
+              "code":"REC",
+              "display":"recorder"
+            }
+          ]
+        }
+      ],
+      "individual":{
+        "reference":"Practitioner/6D340A1B-BC15-4D4E-93CF-BBCB5B74DF73"
+      }
+    }
+  ],
+  "period":{
+    "start":"2010-01-13T15:20:00+00:00"
+  },
+  "location":[
+    {
+      "location":{
+        "reference":"Location/EB3994A6-5A87-4B53-A414-913137072F57"
+      }
+    }
+  ],
+  "serviceProvider":{
+    "reference":"Organization/5E496953-065B-41F2-9577-BE8F2FBD0757"
+  }
+}

--- a/service/src/test/resources/ehr/mapper/encounter/output-with-confidentiality-code.xml
+++ b/service/src/test/resources/ehr/mapper/encounter/output-with-confidentiality-code.xml
@@ -1,0 +1,61 @@
+<component typeCode="COMP">
+    <ehrComposition classCode="COMPOSITION" moodCode="EVN">
+        <id root="test-id" />
+        <code code="24671000000101" displayName="Telephone call to a patient" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"><originalText>GP Surgery</originalText></code>
+        <statusCode code="COMPLETE" />
+        <effectiveTime>
+            <center value="20100113152000"/>
+        </effectiveTime>
+        <availabilityTime value="20100113152000" />
+        <confidentialityCode
+          code="NOPAT"
+          codeSystem="2.16.840.1.113883.4.642.3.47"
+          displayName="no disclosure to patient, family or caregivers without attending provider's authorization" />
+        <author typeCode="AUT" contextControlCode="OP">
+            <time value="20100113151332" />
+            <agentRef classCode="AGNT">
+                <id root="test-id" />
+            </agentRef>
+        </author>
+        <location typeCode="LOC">
+            <locatedEntity classCode="LOCE">
+                <code code="394730007" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="Healthcare related organisation" />
+                <locatedPlace classCode="PLC" determinerCode="INSTANCE">
+                    <name>Test Location</name>
+                </locatedPlace>
+            </locatedEntity>
+        </location>
+        <Participant2 typeCode="PRF" contextControlCode="OP">
+            <agentRef classCode="AGNT">
+                <id root="test-id" />
+            </agentRef>
+        </Participant2>
+        <component typeCode="COMP" >
+    <ObservationStatement classCode="OBS" moodCode="EVN">
+        <id root="BA6EA7CB-3E2F-46FA-918C-C0B5178C1D4E" />
+        <code code="907511000006105" codeSystem="2.16.840.1.113883.2.1.3.2.4.15" displayName="[RFC] Chest infection">
+            <originalText>Test</originalText>
+        </code>
+        <statusCode code="COMPLETE" />
+        <effectiveTime>
+            <center value="20201110115000"/>
+        </effectiveTime>
+        <availabilityTime value="20201110115000"/>
+
+
+        <pertinentInformation typeCode="PERT">
+            <sequenceNumber value="+1" />
+            <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                <text>Test Observation</text>
+            </pertinentAnnotation>
+        </pertinentInformation>
+
+        <Participant typeCode="PRF" contextControlCode="OP">
+            <agentRef classCode="AGNT">
+                <id root="6423EA0F-1F1C-4255-AEBA-D142BE836D50"/>
+            </agentRef>
+        </Participant>
+    </ObservationStatement>
+</component>
+    </ehrComposition>
+</component>


### PR DESCRIPTION
## What

Send over Encounter.meta.security NOPAT field to incumbent

## Why

Making Encounter resource compliant with Redactions changes

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
