### PR TITLE
NIAD-3157: Send over uncategorised data observation NOPAT field to incumbent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-The GP2GP Adaptor now adds the EhrComposition / confidentialityCode field when Encounter.meta.security contains NOPAT security entry
-
+* The GP2GP Adaptor now adds the EhrComposition / confidentialityCode field when Encounter.meta.security contains NOPAT security entry
+* The GP2GP Adaptor now populates the ObservationStatement / confidentialityCode field when the .meta.security field of an Uncategorised Data Observation contains NOPAT
 
 ## [2.4.0] - 2025-04-02
 

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -73,7 +73,7 @@ dependencies {
 	testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 	testImplementation 'io.findify:s3mock_2.13:0.2.6'
 
-	pitest 'com.arcmutate:base:1.3.2'
+	pitest 'com.arcmutate:base:1.4.0'
 	pitest 'com.arcmutate:pitest-git-plugin:2.2.1'
 }
 

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -73,8 +73,8 @@ dependencies {
 	testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 	testImplementation 'io.findify:s3mock_2.13:0.2.6'
 
-	pitest 'com.arcmutate:base:1.4.0'
-	pitest 'com.arcmutate:pitest-git-plugin:2.2.1'
+	pitest 'com.arcmutate:base:1.3.2'
+	pitest 'com.arcmutate:pitest-git-plugin:2.1.0'
 }
 
 test {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/ObservationStatementTemplateParameters.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/parameters/ObservationStatementTemplateParameters.java
@@ -11,6 +11,7 @@ public class ObservationStatementTemplateParameters {
     private String observationStatementId;
     private String comment;
     private String effectiveTime;
+    private String confidentialityCode;
     private String issued;
     private String value;
     private String referenceRange;

--- a/service/src/main/resources/templates/unstructured_observation_statement_template.mustache
+++ b/service/src/main/resources/templates/unstructured_observation_statement_template.mustache
@@ -6,6 +6,9 @@
         <effectiveTime>
             {{{effectiveTime}}}
         </effectiveTime>
+        {{#confidentialityCode}}
+            {{{confidentialityCode}}}
+        {{/confidentialityCode}}
         {{{issued}}}
         {{{value}}}
         {{{interpretation}}}

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EhrExtractMapperComponentTest.java
@@ -185,7 +185,8 @@ public class EhrExtractMapperComponentTest {
                 new StructuredObservationValueMapper(),
                 new PertinentInformationObservationValueMapper(),
                 codeableConceptCdMapper,
-                participantMapper
+                participantMapper,
+                confidentialityService
             ),
             new RequestStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService),
             new DiagnosticReportMapper(

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterComponentsMapperTest.java
@@ -183,7 +183,8 @@ public class EncounterComponentsMapperTest {
             messageContext,
             structuredObservationValueMapper,
             new PertinentInformationObservationValueMapper(), codeableConceptCdMapper,
-            participantMapper
+            participantMapper,
+            confidentialityService
         );
         ImmunizationObservationStatementMapper immunizationObservationStatementMapper =
             new ImmunizationObservationStatementMapper(

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/ObservationStatementMapperTest.java
@@ -228,7 +228,7 @@ public class ObservationStatementMapperTest {
     }
 
     @Test
-    public void When_MappingParsedObservationWithNopat_Expect_ObservationStatementWithConfidentialityCode() {
+    void When_MappingParsedObservationWithNopat_Expect_ObservationStatementWithConfidentialityCode() {
         expectedOutputMessage = ResourceTestFileUtils.getFileContent(OUTPUT_XML_WITH_NOPAT);
         var jsonInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_WITH_NOPAT);
         Observation parsedObservation = new FhirParseService().parseResource(jsonInput, Observation.class);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/uat/EhrExtractUATTest.java
@@ -205,7 +205,8 @@ public class EhrExtractUATTest {
                 new StructuredObservationValueMapper(),
                 new PertinentInformationObservationValueMapper(),
                 codeableConceptCdMapper,
-                participantMapper
+                participantMapper,
+                confidentialityService
             ),
             new RequestStatementMapper(messageContext, codeableConceptCdMapper, participantMapper, confidentialityService),
             new DiagnosticReportMapper(messageContext, specimenMapper, participantMapper, randomIdGeneratorService, confidentialityService),

--- a/service/src/test/resources/ehr/mapper/observation/example-observation-resource-with-nopat.json
+++ b/service/src/test/resources/ehr/mapper/observation/example-observation-resource-with-nopat.json
@@ -1,0 +1,20 @@
+{
+    "resourceType": "Observation",
+    "id": "3377543D-5B1B-4C4F-BFF6-9F7BC3A1C3B8",
+    "meta": {
+        "profile": [
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-Immunization-1"
+        ],
+        "security": [{
+            "system":"http://hl7.org/fhir/v3/ActCode",
+            "code":"NOPAT",
+            "display":"no disclosure to patient, family or caregivers without attending provider's authorization"
+        }]
+    },
+    "code": {
+        "text": "test"
+    },
+    "effectiveDateTime": "2010-07-14T16:32:51.42+01:00",
+    "issued": "2010-01-13T15:29:50.3+00:00",
+    "comment": "1.This is a line of \"text\" with a line break at the end.\n2."
+}

--- a/service/src/test/resources/ehr/mapper/observation/expected-observation-statement-with-confidentiality-code.xml
+++ b/service/src/test/resources/ehr/mapper/observation/expected-observation-statement-with-confidentiality-code.xml
@@ -1,0 +1,22 @@
+<component typeCode="COMP" contextConductionInd="true">
+    <ObservationStatement classCode="OBS" moodCode="EVN">
+        <id root="394559384658936" />
+        <code nullFlavor="UNK"><originalText>Mocked code</originalText></code>
+        <statusCode code="COMPLETE" />
+        <effectiveTime>
+            <center value="20100714163251"/>
+        </effectiveTime>
+        <confidentialityCode
+          code="NOPAT"
+          codeSystem="2.16.840.1.113883.4.642.3.47"
+          displayName="no disclosure to patient, family or caregivers without attending provider's authorization" />
+        <availabilityTime value="20100714163251"/>
+        <pertinentInformation typeCode="PERT">
+            <sequenceNumber value="+1" />
+            <pertinentAnnotation classCode="OBS" moodCode="EVN">
+                <text>1.This is a line of &quot;text&quot; with a line break at the end.</text>
+            </pertinentAnnotation>
+        </pertinentInformation>
+        
+    </ObservationStatement>
+</component>


### PR DESCRIPTION
## What

Send over Observation (uncategorised data).meta.security NOPAT field to incumbent

## Why
Making Observation (uncategorised data) compliant with Redactions

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
