### PR TITLE
NIAD-3294 - Allow RequestStatementMapper to handle updated UBRN system URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The GP2GP Adaptor now populates the ObservationStatement / confidentialityCode field when the .meta.security field of an Uncategorised Data Observation contains NOPAT
 * When List.meta.security field contains NOPAT, the GP2GP Adaptor will now populate the CompoundStatement.confidentialityCode
 
+### Update
+* The GP2GP Adaptor is now able to identify e-referrals by using either `https://fhir.nhs.uk/Id/ubr-number` or `https://fhir.nhs.uk/Id/UBRN` when provided as an identifier system URL.
+
 
 ## [2.4.0] - 2025-04-02
 

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -10,7 +10,7 @@ plugins {
 
 	// Mutation testing
 	id 'info.solidsoft.pitest' version '1.15.0'
-	id 'com.arcmutate.github' version '2.2.2'
+	id 'com.arcmutate.github' version '2.2.1'
 }
 
 apply plugin: 'java'
@@ -73,8 +73,8 @@ dependencies {
 	testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 	testImplementation 'io.findify:s3mock_2.13:0.2.6'
 
-	pitest 'com.arcmutate:base:1.4.2'
-	pitest 'com.arcmutate:pitest-git-plugin:2.2.3'
+	pitest 'com.arcmutate:base:1.3.2'
+	pitest 'com.arcmutate:pitest-git-plugin:2.1.0'
 }
 
 test {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapper.java
@@ -46,7 +46,8 @@ import uk.nhs.adaptors.gp2gp.ehr.utils.TemplateUtils;
 public class RequestStatementMapper {
     private static final Mustache REQUEST_STATEMENT_TEMPLATE = TemplateUtils.loadTemplate("ehr_request_statement_template.mustache");
 
-    private static final String UBRN_SYSTEM_URL = "https://fhir.nhs.uk/Id/ubr-number";
+    private static final String UBRN_SYSTEM_URL = "https://fhir.nhs.uk/Id/UBRN";
+    private static final String UBR_NUMBER_SYSTEM_URL = "https://fhir.nhs.uk/Id/ubr-number";
     private static final String REQUESTER_DEVICE = "Requester Device: ";
     private static final String REQUESTER_PATIENT = "Requester: Patient";
     private static final String REQUESTER_ORG = "Requester Org: ";
@@ -173,7 +174,7 @@ public class RequestStatementMapper {
                 .map(ReferralRequest::getIdentifier)
                 .flatMap(List::stream)
                 .filter(Objects::nonNull)
-                .filter(val -> UBRN_SYSTEM_URL.equals(val.getSystem()))
+                .filter(val -> UBRN_SYSTEM_URL.equals(val.getSystem()) || UBR_NUMBER_SYSTEM_URL.equals(val.getSystem()))
                 .map(Identifier::getValue)
                 .findAny()
                 .map(UBRN::concat)

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapperTest.java
@@ -123,7 +123,10 @@ public class RequestStatementMapperTest {
         + "example-referral-request-supportingInfo-with-ignored-resources.json";
     private static final String INPUT_JSON_WITH_NO_AUTHOR_AND_TIME = TEST_FILE_DIRECTORY
         + "example-referral-request-no-author-and-time.json";
-
+    private static final String INPUT_JSON_WITH_WITH_UBR_NUMBER_SYSTEM_URL = TEST_FILE_DIRECTORY
+            + "example-referral-request-with-ubr-number-system-url.json";
+    private static final String INPUT_JSON_WITH_WITH_UBRN_SYSTEM_URL = TEST_FILE_DIRECTORY
+            + "example-referral-request-with-ubrn-system-url.json";
 
     // OUTPUT FILES
     private static final String OUTPUT_XML_USES_NO_OPTIONAL_FIELDS = TEST_FILE_DIRECTORY
@@ -190,6 +193,8 @@ public class RequestStatementMapperTest {
         + "expected-output-request-statement-no-supportingInfo.xml";
     private static final String OUTPUT_XML_WITH_NO_AUTHOR_AND_TIME = TEST_FILE_DIRECTORY
         + "expected-output-request-statement-no-author-and-time.xml";
+    private static final String OUTPUT_XML_WITH_SYSTEM_URL = TEST_FILE_DIRECTORY
+            + "expected-output-request-for-system-url.xml";
 
     @Mock
     private CodeableConceptCdMapper codeableConceptCdMapper;
@@ -225,7 +230,7 @@ public class RequestStatementMapperTest {
             arguments(INPUT_JSON_WITH_ROUTINE_PRIORITY, OUTPUT_XML_WITH_NORMAL_PRIORITY),
             arguments(INPUT_JSON_WITH_URGENT_PRIORITY, OUTPUT_XML_WITH_HIGH_PRIORITY),
             arguments(INPUT_JSON_WITH_SUPPORTINGINFO_DOCUMENTREFERENCE,
-                OUTPUT_XML_WITH_SUPPORTINGINFO_DOCUMENTREFERENCE),
+                    OUTPUT_XML_WITH_SUPPORTINGINFO_DOCUMENTREFERENCE),
             arguments(INPUT_JSON_WITH_SUPPORTINGINFO_DOCUMENTREFERENCE_NO_DESCRIPTION,
                 OUTPUT_XML_WITH_SUPPORTINGINFO_DOCUMENTREFERENCE_NO_DESCRIPTION),
             arguments(INPUT_JSON_WITH_SUPPORTINGINFO_DOCUMENTREFERENCE_NO_CREATED_NO_TEXT,
@@ -252,7 +257,9 @@ public class RequestStatementMapperTest {
                 OUTPUT_XML_WITH_SUPPORTINGINFO_MEDICATIONREQUEST_NO_DATE),
             arguments(INPUT_JSON_WITH_SUPPORTINGINFO_IGNORED_RESOURCES,
                 OUTPUT_XML_WITH_NO_SUPPORTINGINFO),
-            arguments(INPUT_JSON_WITH_NO_AUTHOR_AND_TIME, OUTPUT_XML_WITH_NO_AUTHOR_AND_TIME)
+            arguments(INPUT_JSON_WITH_NO_AUTHOR_AND_TIME, OUTPUT_XML_WITH_NO_AUTHOR_AND_TIME),
+            arguments(INPUT_JSON_WITH_WITH_UBR_NUMBER_SYSTEM_URL, OUTPUT_XML_WITH_SYSTEM_URL),
+            arguments(INPUT_JSON_WITH_WITH_UBRN_SYSTEM_URL, OUTPUT_XML_WITH_SYSTEM_URL)
         );
     }
 

--- a/service/src/test/resources/ehr/mapper/referral/example-referral-request-with-ubr-number-system-url.json
+++ b/service/src/test/resources/ehr/mapper/referral/example-referral-request-with-ubr-number-system-url.json
@@ -1,0 +1,24 @@
+{
+    "resourceType": "ReferralRequest",
+    "id": "E63AF323-919F-4D5F-9A1D-BA933BC230BC",
+    "description": "Referred for investigation into low blood pressure",
+    "specialty": {
+        "coding": [
+            {
+                "system": "http://hl7.org/fhir/v3/NullFlavor",
+                "code": "UNK",
+                "display": "unknown"
+            }
+        ]
+    },
+    "identifier": [
+        {
+            "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+            "value": "B154D1A3-D631-49BD-8B67-2F76D7D85865"
+        },
+        {
+            "system": "https://fhir.nhs.uk/Id/ubr-number",
+            "value": "bb2378b6-dde2-11e9-9d36-2a2ae2dbcce4"
+        }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/referral/example-referral-request-with-ubrn-system-url.json
+++ b/service/src/test/resources/ehr/mapper/referral/example-referral-request-with-ubrn-system-url.json
@@ -1,0 +1,24 @@
+{
+  "resourceType": "ReferralRequest",
+  "id": "E63AF323-919F-4D5F-9A1D-BA933BC230BC",
+  "description": "Referred for investigation into low blood pressure",
+  "specialty": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/v3/NullFlavor",
+        "code": "UNK",
+        "display": "unknown"
+      }
+    ]
+  },
+  "identifier": [
+    {
+      "system": "https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+      "value": "B154D1A3-D631-49BD-8B67-2F76D7D85865"
+    },
+    {
+      "system": "https://fhir.nhs.uk/Id/UBRN",
+      "value": "bb2378b6-dde2-11e9-9d36-2a2ae2dbcce4"
+    }
+  ]
+}

--- a/service/src/test/resources/ehr/mapper/referral/expected-output-request-for-system-url.xml
+++ b/service/src/test/resources/ehr/mapper/referral/expected-output-request-for-system-url.xml
@@ -1,0 +1,12 @@
+<component typeCode="COMP" >
+    <RequestStatement classCode="OBS" moodCode="RQO">
+        <id root="II-for-ReferralRequest-E63AF323-919F-4D5F-9A1D-BA933BC230BC" />
+        <code code="3457005" displayName="Patient referral" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+        <text>UBRN: bb2378b6-dde2-11e9-9d36-2a2ae2dbcce4 Specialty: unknown Referred for investigation into low blood pressure</text>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center nullFlavor="NI"/>
+        </effectiveTime>
+        <availabilityTime nullFlavor="UNK"/>
+    </RequestStatement>
+</component>


### PR DESCRIPTION
## What

RequestStatementMapper is currently filtering for e-referrals by checking for any ReferralRequest using an identifier url of `https://fhir.nhs.uk/Id/ubr-number`.

Therefore we have updated this adaptor to be able to filter for both types of url when filtering to ensure that we can accept both the new url and the older one for systems which are still using it.

## Why

The ERS (E-Referral Service) programme have chosen to use https://fhir.nhs.uk/Id/UBRN.

## Type of change

Please delete options that are not relevant.

- [X ] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
