### PR TITLE
NIAD-3301: Update MedicationRequest.medication datatype support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * The GP2GP Adaptor now adds the EhrComposition / confidentialityCode field when Encounter.meta.security contains NOPAT security entry
-* The GP2GP Adaptor now populates the ObservationStatement / confidentialityCode field when the .meta.security field of an Uncategorised Data Observation contains NOPAT
+* The GP2GP Adaptor now populates the ObservationStatement / confidentialityCode field when the .meta.security field of an Uncategorized Data Observation contains NOPAT
 * When List.meta.security field contains NOPAT, the GP2GP Adaptor will now populate the CompoundStatement.confidentialityCode
 
 ### Update
-* The GP2GP Adaptor is now able to identify e-referrals by using either `https://fhir.nhs.uk/Id/ubr-number` or `https://fhir.nhs.uk/Id/UBRN` when provided as an identifier system URL.
+
+* [GP Connect 1.6.1] The GP2GP Adaptor is now able to identify e-referrals by using either `https://fhir.nhs.uk/Id/ubr-number` or `https://fhir.nhs.uk/Id/UBRN` when provided as an identifier system URL.
+* [GP Connect 1.6.2] In a `MedicationRequest` the `Medication` can be provided as a reference to a `Medication` (using `Medication.medicationReference`) or, in the case that only a single resource references this medication, a `Medication.medicationCodeableConcept` can be used instead.) 
 
 
 ## [2.4.0] - 2025-04-02

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapper.java
@@ -148,6 +148,10 @@ public class MedicationStatementMapper {
     }
 
     private String buildMedicationReferenceCode(MedicationRequest medicationRequest) {
+        if (medicationRequest.hasMedicationCodeableConcept()) {
+            return codeableConceptCdMapper.mapCodeableConceptForMedication(medicationRequest.getMedicationCodeableConcept());
+        }
+
         IIdType reference = medicationRequest.getMedicationReference().getReferenceElement();
         return messageContext.getInputBundleHolder()
             .getResource(reference)

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/utils/SupportingInfoResourceExtractor.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/utils/SupportingInfoResourceExtractor.java
@@ -197,7 +197,11 @@ public class SupportingInfoResourceExtractor {
             }
         }
 
-        if (medicationRequest.hasMedicationReference()) {
+        if (medicationRequest.hasMedicationCodeableConcept()) {
+            var medicationCodeableConceptText = CodeableConceptMappingUtils.extractTextOrCoding(medicationRequest.getMedicationCodeableConcept());
+
+            medicationCodeableConceptText.ifPresent(text -> stringBuilder.append(" ").append(text));
+        } else if (medicationRequest.hasMedicationReference()) {
             messageContext
                 .getInputBundleHolder()
                 .getResource(medicationRequest.getMedicationReference().getReferenceElement())

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/MedicationStatementMapperTest.java
@@ -107,6 +107,10 @@ public class MedicationStatementMapperTest {
     private static Stream<Arguments> resourceFileParams() {
         return Stream.of(
             Arguments.of("mr-with-order-no-optional-fields.json", "medication-statement-with-prescribe-no-optional-fields.xml"),
+            Arguments.of(
+                "mr-with-order-no-optional-fields-with-medication-codeable-concept.json",
+                "medication-statement-with-prescribe-no-optional-fields.xml"
+            ),
             Arguments.of("mr-with-order-optional-fields.json", "medication-statement-with-prescribe-optional-fields.xml"),
             Arguments.of("mr-with-complete-status.json", "medication-statement-with-complete-status.xml"),
             Arguments.of("mr-with-active-status.json", "medication-statement-with-active-status.xml"),

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapperTest.java
@@ -119,6 +119,8 @@ public class RequestStatementMapperTest {
             + "example-referral-request-supportingInfo-with-medication-request.json";
     private static final String INPUT_JSON_WITH_SUPPORTINGINFO_MEDICATIONREQUEST_NO_DATE = TEST_FILE_DIRECTORY
         + "example-referral-request-supportingInfo-with-medication-request-no-date.json";
+    private static final String INPUT_JSON_WITH_SUPPORTINGINFO_MEDICATION_REQUEST_WITH_MEDICATION_CODEABLE_CONCEPT = TEST_FILE_DIRECTORY
+            + "example-referral-request-supportingInfo-medication-request-with-medication-codeable-concept.json";
     private static final String INPUT_JSON_WITH_SUPPORTINGINFO_IGNORED_RESOURCES = TEST_FILE_DIRECTORY
         + "example-referral-request-supportingInfo-with-ignored-resources.json";
     private static final String INPUT_JSON_WITH_NO_AUTHOR_AND_TIME = TEST_FILE_DIRECTORY

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapperTest.java
@@ -211,8 +211,6 @@ public class RequestStatementMapperTest {
     @Mock
     private ConfidentialityService confidentialityService;
 
-    private InputBundle inputBundle;
-
     private RequestStatementMapper requestStatementMapper;
 
     private static Stream<Arguments> resourceFileParams() {
@@ -261,10 +259,11 @@ public class RequestStatementMapperTest {
                 OUTPUT_XML_WITH_SUPPORTINGINFO_MEDICATIONREQUEST_NO_DATE),
             arguments(INPUT_JSON_WITH_SUPPORTINGINFO_IGNORED_RESOURCES,
                 OUTPUT_XML_WITH_NO_SUPPORTINGINFO),
-            arguments(INPUT_JSON_WITH_NO_AUTHOR_AND_TIME, OUTPUT_XML_WITH_NO_AUTHOR_AND_TIME),
-            arguments(INPUT_JSON_WITH_WITH_UBR_NUMBER_SYSTEM_URL, OUTPUT_XML_WITH_SYSTEM_URL),
             arguments(INPUT_JSON_WITH_WITH_UBRN_SYSTEM_URL, OUTPUT_XML_WITH_SYSTEM_URL),
-                arguments(INPUT_JSON_WITH_SUPPORTINGINFO_MEDICATION_REQUEST_WITH_MEDICATION_CODEABLE_CONCEPT, OUTPUT_XML_WITH_SUPPORTINGINFO_FROM_MEDICATION_CODEABLE_CONCEPT_DISPLAY)
+            arguments(INPUT_JSON_WITH_SUPPORTINGINFO_MEDICATION_REQUEST_WITH_MEDICATION_CODEABLE_CONCEPT,
+                OUTPUT_XML_WITH_SUPPORTINGINFO_FROM_MEDICATION_CODEABLE_CONCEPT_DISPLAY),
+            arguments(INPUT_JSON_WITH_NO_AUTHOR_AND_TIME, OUTPUT_XML_WITH_NO_AUTHOR_AND_TIME),
+            arguments(INPUT_JSON_WITH_WITH_UBR_NUMBER_SYSTEM_URL, OUTPUT_XML_WITH_SYSTEM_URL)
         );
     }
 
@@ -291,7 +290,7 @@ public class RequestStatementMapperTest {
     public void setUp() {
         var bundleInput = ResourceTestFileUtils.getFileContent(INPUT_JSON_BUNDLE);
         Bundle bundle = new FhirParseService().parseResource(bundleInput, Bundle.class);
-        inputBundle = new InputBundle(bundle);
+        var inputBundle = new InputBundle(bundle);
 
         lenient().when(messageContext.getIdMapper()).thenReturn(idMapper);
         lenient().when(messageContext.getAgentDirectory()).thenReturn(agentDirectory);

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapperTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/ehr/mapper/RequestStatementMapperTest.java
@@ -191,6 +191,8 @@ public class RequestStatementMapperTest {
             + "expected-output-request-statement-supportingInfo-with-medication-request.xml";
     private static final String OUTPUT_XML_WITH_SUPPORTINGINFO_MEDICATIONREQUEST_NO_DATE = TEST_FILE_DIRECTORY
         + "expected-output-request-statement-supportingInfo-with-medication-request-no-date.xml";
+    private static final String OUTPUT_XML_WITH_SUPPORTINGINFO_FROM_MEDICATION_CODEABLE_CONCEPT_DISPLAY = TEST_FILE_DIRECTORY
+            + "expected-output-request-statement-supportingInfo-from-medication-codeable-concept-display.xml";
     private static final String OUTPUT_XML_WITH_NO_SUPPORTINGINFO = TEST_FILE_DIRECTORY
         + "expected-output-request-statement-no-supportingInfo.xml";
     private static final String OUTPUT_XML_WITH_NO_AUTHOR_AND_TIME = TEST_FILE_DIRECTORY
@@ -261,7 +263,8 @@ public class RequestStatementMapperTest {
                 OUTPUT_XML_WITH_NO_SUPPORTINGINFO),
             arguments(INPUT_JSON_WITH_NO_AUTHOR_AND_TIME, OUTPUT_XML_WITH_NO_AUTHOR_AND_TIME),
             arguments(INPUT_JSON_WITH_WITH_UBR_NUMBER_SYSTEM_URL, OUTPUT_XML_WITH_SYSTEM_URL),
-            arguments(INPUT_JSON_WITH_WITH_UBRN_SYSTEM_URL, OUTPUT_XML_WITH_SYSTEM_URL)
+            arguments(INPUT_JSON_WITH_WITH_UBRN_SYSTEM_URL, OUTPUT_XML_WITH_SYSTEM_URL),
+                arguments(INPUT_JSON_WITH_SUPPORTINGINFO_MEDICATION_REQUEST_WITH_MEDICATION_CODEABLE_CONCEPT, OUTPUT_XML_WITH_SUPPORTINGINFO_FROM_MEDICATION_CODEABLE_CONCEPT_DISPLAY)
         );
     }
 

--- a/service/src/test/resources/ehr/mapper/medication_request/mr-with-order-no-optional-fields-with-medication-codeable-concept.json
+++ b/service/src/test/resources/ehr/mapper/medication_request/mr-with-order-no-optional-fields-with-medication-codeable-concept.json
@@ -1,0 +1,65 @@
+{
+    "resourceType":"MedicationRequest",
+    "id":"3377543D-5B1B-4C4F-BFF6-9F7BC3A1C3B8",
+    "meta":{
+        "profile":[
+            "https://fhir.nhs.uk/STU3/StructureDefinition/CareConnect-GPC-MedicationRequest-1"
+        ]
+    },
+    "extension":[
+        {
+            "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-CareConnect-GPC-MedicationRepeatInformation-1",
+            "extension": [
+                {
+                    "url": "numberOfRepeatPrescriptionsAllowed",
+                    "valuePositiveInt": 12
+                },
+                {
+                    "url": "numberOfRepeatPrescriptionsIssued",
+                    "valuePositiveInt": 11
+                }
+            ]
+        }
+    ],
+    "identifier":[
+        {
+            "system":"https://fhir.nhs.uk/Id/cross-care-setting-identifier",
+            "value":"f2489066-7082-11eb-bb13-00505692d4aa"
+        }
+    ],
+    "status":"active",
+    "intent":"order",
+    "medicationCodeableConcept": {
+        "coding": [
+            {
+                "system": "http://snomed.info/sct",
+                "code": "430127000",
+                "display": "Oral Form Oxycodone (product)"
+            }
+        ]
+    },
+    "subject":{
+        "reference":"Patient/2"
+    },
+    "authoredOn":"2017-11-10T00:00:00+00:00",
+    "recorder":{
+        "reference":"Practitioner/1"
+    },
+    "dosageInstruction":[
+        {
+            "text":"1 tablet once a day",
+            "patientInstruction":"Take in morning"
+        }
+    ],
+    "dispenseRequest":{
+        "validityPeriod":{
+            "start":"2017-11-10T00:00:00+00:00",
+            "end":"2018-08-15T00:00:00+01:00"
+        }
+    },
+    "basedOn": [
+        {
+            "reference": "MedicationRequest/D66D84C9-C073-4EDF-8C2C-F309A83C3DC7"
+        }
+    ]
+}

--- a/service/src/test/resources/ehr/mapper/referral/example-referral-request-supportingInfo-medication-request-with-medication-codeable-concept.json
+++ b/service/src/test/resources/ehr/mapper/referral/example-referral-request-supportingInfo-medication-request-with-medication-codeable-concept.json
@@ -1,0 +1,9 @@
+{
+  "resourceType": "ReferralRequest",
+  "id": "2FB2C828-F8EC-11EB-9A03-0242AC130003",
+  "supportingInfo": [
+    {
+      "reference": "MedicationRequest/2F40AD96-F910-11EB-9A03-0242AC139999"
+    }
+  ]
+}

--- a/service/src/test/resources/ehr/mapper/referral/example-referral-request-supportingInfo-medication-request-with-medication-codeable-concept.json
+++ b/service/src/test/resources/ehr/mapper/referral/example-referral-request-supportingInfo-medication-request-with-medication-codeable-concept.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "ReferralRequest",
-  "id": "2FB2C828-F8EC-11EB-9A03-0242AC130003",
+  "id": "2FB2C828-F8EC-11EB-9A03-0242AC139999",
   "supportingInfo": [
     {
       "reference": "MedicationRequest/2F40AD96-F910-11EB-9A03-0242AC139999"

--- a/service/src/test/resources/ehr/mapper/referral/expected-output-request-statement-supportingInfo-from-medication-codeable-concept-display.xml
+++ b/service/src/test/resources/ehr/mapper/referral/expected-output-request-statement-supportingInfo-from-medication-codeable-concept-display.xml
@@ -1,0 +1,12 @@
+<component typeCode="COMP" >
+    <RequestStatement classCode="OBS" moodCode="RQO">
+        <id root="II-for-ReferralRequest-2FB2C828-F8EC-11EB-9A03-0242AC139999" />
+        <code code="3457005" displayName="Patient referral" codeSystem="2.16.840.1.113883.2.1.3.2.4.15"/>
+        <text>Supporting Information: { Medication: 2021-01-01 Oral Form Oxycodone (product) } </text>
+        <statusCode code="COMPLETE"/>
+        <effectiveTime>
+            <center nullFlavor="NI"/>
+        </effectiveTime>
+        <availabilityTime nullFlavor="UNK"/>
+    </RequestStatement>
+</component>

--- a/service/src/test/resources/ehr/mapper/referral/fhir-bundle.json
+++ b/service/src/test/resources/ehr/mapper/referral/fhir-bundle.json
@@ -491,6 +491,27 @@
         },
         {
             "resource": {
+                "resourceType": "MedicationRequest",
+                "id": "2F40AD96-F910-11EB-9A03-0242AC139999",
+                "dispenseRequest": {
+                    "validityPeriod": {
+                        "start": "2021-01-01T00:00:00+00:00",
+                        "end": "2021-02-01T00:00:00+01:00"
+                    }
+                },
+                "medicationCodeableConcept": {
+                    "coding": [
+                        {
+                            "system": "http://snomed.info/sct",
+                            "code": "430127000",
+                            "display": "Oral Form Oxycodone (product)"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "resource": {
                 "resourceType": "Medication",
                 "id": "9999",
                 "code": {


### PR DESCRIPTION
## What

* Add test and test file where the `MedicationRequest` contains a `medicationCodableConcept` and not a `medication.reference` to ensure that this is used if it is provided.
* Update `MedicationStatementMapper` to implement this.
* Add test and test file where 'SupportingInfo` is generated from a medication request and the referenced `MedicationRequest` contains a `medicationCodableConcept` and not a `medication.reference` to ensure that this is used if it is provided.
* Update the `fhir-bundle.json` test file to add new MedicationRequest with a `medicationCodeableConcept`
* Ensure existing tests still pass using the original functionality

## Why

MedicationRequest and MedicationStatement profiles have had the constraint on the medication element relaxed so they align with the base profile i.e. medication can be either a reference or a CodeableConcept. This is to accommodate use cases such as updating the record where only a single medication is needed and a CodeableConcept would mean a separate Medication resource is not needed as there would be no other references to it. The guidance is for both consumers and suppliers to treat the element as if it is a reference.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
