### PR TITLE
NIAD-1805: Fix vulnerabilities in dependencies

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -55,7 +55,7 @@ dependencies {
 	implementation 'org.apache.qpid:qpid-jms-client:2.7.0'
 
 	// Utils
-	implementation 'org.apache.commons:commons-lang3:3.17.0'
+	implementation 'org.apache.commons:commons-lang3:3.18.0'
 	implementation 'javax.xml.soap:javax.xml.soap-api:1.4.0'
 	implementation 'com.github.spullara.mustache.java:compiler:0.9.14'
 	implementation 'org.apache.tika:tika-core:3.2.0'
@@ -66,12 +66,14 @@ dependencies {
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation "org.assertj:assertj-core:3.27.3"
+	testImplementation 'org.apache.commons:commons-compress:1.28.0'
 	testImplementation 'org.testcontainers:testcontainers:1.21.3'
+	testImplementation 'org.testcontainers:junit-jupiter:1.21.3'
 	testImplementation 'org.awaitility:awaitility:4.3.0'
 	testImplementation 'org.wiremock:wiremock-standalone:3.13.0'
 	testImplementation 'com.squareup.okhttp3:okhttp:4.12.0'
 	testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
-	testImplementation 'io.findify:s3mock_2.13:0.2.6'
+	testImplementation 'com.adobe.testing:s3mock-testcontainers:4.7.0'
 
 	pitest 'com.arcmutate:base:1.3.2'
 	pitest 'com.arcmutate:pitest-git-plugin:2.1.0'


### PR DESCRIPTION
* Address vulnerability in `org.testcontainers:testcontainers:1.21.3`.  This occurs due to a bug (which will not be fixed) in the `commons-compress` version used.  This addressed this by importing an implementation of `common-compress` where the vulnerability exists and allowing this to override the `TestContainers` version.
* Remove `io.findify:s3mock_2.13:0.2.6` as this project has now been abandoned and  archived.  Switched instead to use `com.adobe.testing:s3mock-testcontainers:4.7.0` as this is in active development and is the recommended replacement.
* Update the unit tests previously using `findify:s3mock` to use the test container instead, and removed now unneeded constants.
* Update `org.apache.commons:commons-lang3:3.17.0` to version `3.18.0` where the vulnerability has been resolved.

## What

* Address vulnerability in `org.testcontainers:testcontainers:1.21.3`. 
* * Update `org.apache.commons:commons-lang3:3.17.0` to version `3.18.0` where the vulnerability has been resolved.
* Remove `io.findify:s3mock_2.13:0.2.6` and replace with `com.adobe.testing:s3mock-testcontainers:4.7.0` 
* Update the unit tests previously using `findify:s3mock` to use the test container instead, and removed now unneeded constants.

## Why

Currently there are three package vulnerabilities:

 org.testcontainers:testcontainers:1.21.3 - This is is reference in [Issue #8338](https://github.com/testcontainers/testcontainers-java/issues/8338) - There does not appear to any efforts by the developer to resolve this, but a work around has been suggested to override the implementation of commons-compress with a later version which does not contain the vulnerability.  This has now been completed and the vulnerability is resolved.

io.findify:s3mock_2.13:0.2.6 - This is an [abandoned and archived project](https://github.com/findify/s3mock) and should no longer be used.  Most recommendations suggest moving to the adobe implementation (com.adobe.testing:s3mock-testcontainers) as this is in active development and works via test containers for easy setup.  This has been implemented and the consuming classes updated to use the adobe implementation.

'org.apache.commons:commons-lang3:3.17.0' - This contains a vulnerability which is resolved in the new relase 3.18.0.  This has been updated and the vulnerability resolved.


## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
