### PR TITLE
Replace jupiter api and engine packages with combined import

### DIFF
--- a/e2e-tests/build.gradle
+++ b/e2e-tests/build.gradle
@@ -20,13 +20,11 @@ dependencies {
     testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.19.2'
     testImplementation 'commons-io:commons-io:2.19.0'
     testImplementation 'org.awaitility:awaitility:4.3.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.4'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testImplementation "org.assertj:assertj-core:3.27.3"
     testImplementation 'ch.qos.logback:logback-classic:1.5.18'
     testImplementation 'org.xmlunit:xmlunit-assertj3:2.10.3'
     testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.5'
-
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.11.4'
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
* Replaced separate packages with combined package (`org.junit.jupiter:junit-jupiter:5.13.4`) as both removed packages were required to be the same version, causing dependabot issues.

## What

* Replaced separate packages with combined package (`org.junit.jupiter:junit-jupiter:5.13.4`) 

## Why

Both removed packages are required to be the same version, causing dependabot issues as it tried to update each independently.  Switch to the combined package for both of those dependencies.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
