### PR TITLE
Consolidate Jupiter Frameworks

### DIFF
--- a/e2e-tests/build.gradle
+++ b/e2e-tests/build.gradle
@@ -20,13 +20,11 @@ dependencies {
     testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.19.2'
     testImplementation 'commons-io:commons-io:2.20.0'
     testImplementation 'org.awaitility:awaitility:4.3.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.4'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.13.4'
     testImplementation "org.assertj:assertj-core:3.27.4"
     testImplementation 'ch.qos.logback:logback-classic:1.5.18'
     testImplementation 'org.xmlunit:xmlunit-assertj3:2.10.3'
     testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.5'
-
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.11.4'
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
## What

Consolidate Jupiter Frameworks in E2E Tests `build.grade`

## Why

We currently specify two packages for junit-jupiter packages.  These are also provided as a consolidated package, which is preferable to use as dependabot tries to 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
