### PR TITLE
Consolidate Jupiter Frameworks

### DIFF
--- a/e2e-tests/build.gradle
+++ b/e2e-tests/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     testImplementation 'ch.qos.logback:logback-classic:1.5.18'
     testImplementation 'org.xmlunit:xmlunit-assertj3:2.10.3'
     testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.5'
+
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
## What

Consolidate Jupiter Frameworks in E2E Tests `build.grade`

## Why

We currently specify two packages for junit-jupiter packages.  These are also provided as a consolidated package, which is preferable to use as dependabot tries to update each one individually.  This fails as all junit-juniper packages need to be aligned.  This alignment can be ensured by referencing the platform BOM for junit.

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes