### PR TITLE
Downgrade `pitest-git-plugin` due to compatibility issues

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -9,7 +9,7 @@ plugins {
 	id 'org.sonarqube' version '6.2.0.5505'
 
 	// Mutation testing
-	id 'info.solidsoft.pitest' version '1.19.0-rc.1'
+	id 'info.solidsoft.pitest' version '1.15.0'
 	id 'com.arcmutate.github' version '2.2.3'
 }
 
@@ -75,8 +75,9 @@ dependencies {
 	testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 	testImplementation 'com.adobe.testing:s3mock-testcontainers:4.7.0'
 
-	pitest 'com.arcmutate:base:1.3.2'
-	pitest 'com.arcmutate:pitest-git-plugin:2.2.4'
+
+    pitest 'com.arcmutate:base:1.3.2'
+    pitest 'com.arcmutate:pitest-git-plugin:2.1.0'
 }
 
 test {


### PR DESCRIPTION
## What

downgrade pitest-git-plugin to 2.1.0 as automatic update appears to have broken our pipeline runs.

## Why

downgrade pitest-git-plugin to 2.1.0 as automatic update appears to have broken our pipeline runs.

## Type of change

Please delete options that are not relevant.


- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
