### PR TITLE
Update release pipeline to allow generating of SBOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,18 @@
 on:
-  push:
-    tags: "*"
+  release:
+    types: [published]
 
 jobs:
   push_to_dockerhub:
     strategy:
       matrix:
-        image:
-          - {folder: service, dockerhub_name: nia-gp2gp-adaptor}
+        config:
+          - folder: service
+            dockerhub_name: nia-gp2gp-adaptor
+            upload_url: ${{ github.event.release.upload_url }}
     uses: NHSDigital/integration-adaptor-actions/.github/workflows/release-adaptor-container-image.yml@main
     with:
-        dockerhub_name: ${{matrix.image.dockerhub_name}}
-        folder: ${{matrix.image.folder}}
-
+        folder: ${{ matrix.config.folder }}
+        dockerhub_name: ${{ matrix.config.dockerhub_name }}
+        upload_url: ${{ matrix.config.upload_url }}
     secrets: inherit


### PR DESCRIPTION
## What

Update release pipeline to allow generating of SBOM

## Why

* Update release pipeline to allow generating of SBOM by passing through the upload_url, allowing the reusable workflow to add the artifact to the release

## Type of change

- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
