### PR TITLE
Fix juniper package issues

### DIFF
--- a/e2e-tests/build.gradle
+++ b/e2e-tests/build.gradle
@@ -16,17 +16,18 @@ dependencies {
     implementation 'org.apache.qpid:qpid-jms-client:2.7.0'
     implementation "org.apache.geronimo.specs:geronimo-jms_1.1_spec:1.1.1"
     implementation 'org.mongodb:mongo-java-driver:3.12.14'
+    testImplementation(platform('org.junit:junit-bom:5.13.4'))
+    testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.19.2'
     testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.19.2'
     testImplementation 'commons-io:commons-io:2.20.0'
     testImplementation 'org.awaitility:awaitility:4.3.0'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.11.4'
     testImplementation "org.assertj:assertj-core:3.27.4"
     testImplementation 'ch.qos.logback:logback-classic:1.5.18'
     testImplementation 'org.xmlunit:xmlunit-assertj3:2.10.3'
     testImplementation 'org.apache.httpcomponents.client5:httpclient5:5.5'
 
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.11.4'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.withType(Test) {


### PR DESCRIPTION
## What

Consolidate Jupiter Frameworks in E2E Tests `build.grade`

## Why

We currently specify two packages for junit-jupiter packages.  These are also provided as a consolidated package, which is preferable to use as dependabot tries to update each one individually.  This fails as all junit-juniper packages need to be aligned.  This alignment can be ensured by referencing the platform BOM for junit.

## Type of change

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes