### PR TITLE
NIAD-3216: When DiagnosticReport doesn't contain a Specimen reference, we are sending a value of DUMMY

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/diagnosticreport/DiagnosticReportMapper.java
@@ -202,7 +202,7 @@ public class DiagnosticReportMapper {
         specimen.setId(DUMMY_SPECIMEN_ID_PREFIX + randomIdGeneratorService.createNewId());
 
         return specimen
-            .setAccessionIdentifier(new Identifier().setValue("DUMMY"))
+            .setAccessionIdentifier(new Identifier().setValue("NOT PRESENT"))
             .setCollection(new Specimen.SpecimenCollectionComponent().setCollected(new DateTimeType(diagnosticReport.getIssued())))
             .setType(new CodeableConcept().setText("UNKNOWN"));
     }

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/diagnostic-report-with-no-specimen.xml
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/diagnostic-report-with-no-specimen.xml
@@ -58,7 +58,7 @@
                 <specimen typeCode="SPC">
                     <specimenRole classCode="SPEC">
                         <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
-                        <id root="2.16.840.1.113883.2.1.4.5.2" extension="DUMMY"/>
+                        <id root="2.16.840.1.113883.2.1.4.5.2" extension="NOT PRESENT"/>
                         <effectiveTime>
                             <center value="20010330162700"/>
                         </effectiveTime>

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/specimen/expected_output_default_empty_specimen.xml
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/specimen/expected_output_default_empty_specimen.xml
@@ -10,7 +10,7 @@
         <specimen typeCode="SPC">
             <specimenRole classCode="SPEC">
                 <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
-                <id root="2.16.840.1.113883.2.1.4.5.2" extension="DUMMY"/>
+                <id root="2.16.840.1.113883.2.1.4.5.2" extension="NOT PRESENT"/>
                 <effectiveTime>
                     <center value="20100223000000"/>
                 </effectiveTime>

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/specimen/expected_output_default_specimen_and_default_observation.xml
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/specimen/expected_output_default_specimen_and_default_observation.xml
@@ -10,7 +10,7 @@
         <specimen typeCode="SPC">
             <specimenRole classCode="SPEC">
                 <id root="5E496953-065B-41F2-9577-BE8F2FBD0757"/>
-                <id root="2.16.840.1.113883.2.1.4.5.2" extension="DUMMY"/>
+                <id root="2.16.840.1.113883.2.1.4.5.2" extension="NOT PRESENT"/>
                 <effectiveTime>
                     <center value="20100223000000"/>
                 </effectiveTime>

--- a/service/src/test/resources/ehr/mapper/diagnosticreport/specimen/input_default_specimen.json
+++ b/service/src/test/resources/ehr/mapper/diagnosticreport/specimen/input_default_specimen.json
@@ -7,7 +7,7 @@
         ]
     },
     "accessionIdentifier": {
-        "value": "DUMMY"
+        "value": "NOT PRESENT"
     },
     "type": {
         "text": "UNKNOWN"


### PR DESCRIPTION
## What

This PR is to implement the bug-fix raised in the ticket [NIAD-3216](https://nhse-dsic.atlassian.net/browse/NIAD-3216).

When testing [NIAD-3213](https://nhse-dsic.atlassian.net/browse/NIAD-3213), it was observed that SystemOne displays the "Specimen ID": of "DUMMY".

## Why

This looks inappropriate within the patient's record. The logic is fine and so it will be changed to "Not present" instead.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users