### PR TITLE
Update SpotBugs to 6.4.0

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'java'
 	id "checkstyle"
-	id "com.github.spotbugs" version "6.1.13"
+	id "com.github.spotbugs" version "6.4.0"
 	id "io.freefair.lombok" version "8.14.2"
 	id 'jacoco'
 	id 'org.sonarqube' version '6.2.0.5505'
@@ -13,16 +13,27 @@ plugins {
 	id 'com.arcmutate.github' version '2.2.3'
 }
 
+spotbugs {
+    toolVersion = '4.9.5'
+}
+
 apply plugin: 'java'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'checkstyle'
 apply plugin: "com.github.spotbugs"
 apply plugin: 'application'
 
-mainClassName = ' uk.nhs.adaptors.gp2gp.Gp2gpApplication'
+application {
+    mainClassName = 'uk.nhs.adaptors.gp2gp.Gp2gpApplication'
+}
 
 group = 'uk.nhs.adaptors'
-sourceCompatibility = '21'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
 
 checkstyle {
 	toolVersion '10.18.2'
@@ -75,6 +86,8 @@ dependencies {
 	testImplementation 'com.squareup.okhttp3:mockwebserver3:5.1.0'
 	testImplementation 'com.adobe.testing:s3mock-testcontainers:4.7.0'
 
+    spotbugs 'com.github.spotbugs:spotbugs:4.9.5'
+    spotbugs 'com.github.spotbugs:spotbugs-annotations:4.9.5'
 
     pitest 'com.arcmutate:base:1.3.2'
     pitest 'com.arcmutate:pitest-git-plugin:2.1.0'
@@ -105,9 +118,10 @@ sourceSets {
 	}
 }
 
-task(interoperabilityTestingToolJsonToXml, dependsOn: 'classes', type: JavaExec) {
-	mainClass.set('uk.nhs.adaptors.gp2gp.transformjsontoxmltool.TransformJsonToXml')
-	classpath = sourceSets.main.runtimeClasspath
+tasks.register('interoperabilityTestingToolJsonToXml', JavaExec) {
+    dependsOn 'classes'
+    mainClass.set('uk.nhs.adaptors.gp2gp.transformjsontoxmltool.TransformJsonToXml')
+    classpath = sourceSets.main.runtimeClasspath
 }
 
 configurations {
@@ -117,21 +131,21 @@ configurations {
 	integrationTestAnnotationProcessor.extendsFrom testAnnotationProcessor
 }
 
-task integrationTest(type: Test) {
-	useJUnitPlatform() {
-		description = 'Runs integration tests.'
-		group = 'verification'
+tasks.register('integrationTest', Test) {
+    useJUnitPlatform() {
+        description = 'Runs integration tests.'
+        group = 'verification'
 
-		testClassesDirs = sourceSets.integrationTest.output.classesDirs
-		classpath = sourceSets.integrationTest.runtimeClasspath
-		shouldRunAfter test
-	}
+        testClassesDirs = sourceSets.integrationTest.output.classesDirs
+        classpath = sourceSets.integrationTest.runtimeClasspath
+        shouldRunAfter test
+    }
 }
 
-tasks.withType(Test) {
-	testLogging {
-		events "passed", "skipped", "failed"
-	}
+tasks.withType(Test).configureEach {
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
 }
 
 check.dependsOn integrationTest
@@ -141,13 +155,13 @@ spotbugsIntegrationTest.enabled = false
 spotbugsMain {
 	reports {
 		html {
-			enabled = true
+			enabled(true)
 		}
 		xml {
-			enabled = true
+			enabled(true)
 		}
-		excludeFilter.set(file("spotbugs/exclude.xml"))
 	}
+    excludeFilter.set(file("spotbugs/exclude.xml"))
 }
 
 pitest {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/configuration/CustomTrustStore.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/configuration/CustomTrustStore.java
@@ -57,7 +57,6 @@ public class CustomTrustStore {
     }
 
     @SneakyThrows
-    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     protected X509TrustManager getCustomDbTrustManager(S3Uri s3Uri, String trustStorePassword) {
         TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
         trustManagerFactory.init((KeyStore) null);

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/mongo/ttl/CosmosTtlCreator.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/mongo/ttl/CosmosTtlCreator.java
@@ -25,7 +25,7 @@ public class CosmosTtlCreator extends TtlCreator {
             String indexName = findTtlIndex().map(IndexInfo::getName).orElseThrow();
             getIndexOperations().dropIndex(indexName);
         }
-        getIndexOperations().ensureIndex(new Index()
+        getIndexOperations().createIndex(new Index()
             .expire(getDuration())
             .on(INDEX_FIELD_KEY, Sort.Direction.ASC)
         );

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/common/mongo/ttl/MongoTtlCreator.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/common/mongo/ttl/MongoTtlCreator.java
@@ -25,7 +25,7 @@ public class MongoTtlCreator extends TtlCreator {
                 clazz.getSimpleName(), getDuration());
             getIndexOperations().dropIndex(TTL_INDEX_NAME);
         }
-        getIndexOperations().ensureIndex(new Index()
+        getIndexOperations().createIndex(new Index()
             .expire(getDuration())
             .named(TTL_INDEX_NAME)
             .on(FIELD_KEY, Sort.Direction.ASC)

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterMapper.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/EncounterMapper.java
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Component;
 
 import com.github.mustachejava.Mustache;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
@@ -171,8 +170,6 @@ public class EncounterMapper {
     }
 
     @SneakyThrows
-    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
-        justification = "https://github.com/spotbugs/spotbugs/issues/1338")
     private static Set<String> getEhrCompositionNameVocabularyCodes() {
         try (InputStream is = EncounterMapper.class.getClassLoader().getResourceAsStream("ehr_composition_name_vocabulary_codes.txt");
              BufferedReader reader = new BufferedReader(new InputStreamReader(is, UTF_8))) {

--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/SupportedContentTypes.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/ehr/mapper/SupportedContentTypes.java
@@ -12,7 +12,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.AllArgsConstructor;
 import lombok.SneakyThrows;
 
@@ -27,8 +26,6 @@ public class SupportedContentTypes {
     }
 
     @SneakyThrows
-    @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
-        justification = "https://github.com/spotbugs/spotbugs/issues/1338")
     private static Set<String> loadSupportedContentTypes() {
         try (InputStream is = SupportedContentTypes.class.getClassLoader().getResourceAsStream(SUPPORTED_CONTENT_TYPES_PATH);
              BufferedReader reader = new BufferedReader(new InputStreamReader(is, UTF_8))) {


### PR DESCRIPTION
## What

* Update SpotBugs to 6.4.0.
* Fix SpotBugs issue relating to deprecated method `.ensureIndex` and replace with `createIndex`
* Fix build.gradle issues
* Remove deprecation suppressors as these are no longer required.
* 
## Why

* After updating SpotBugs, further gradle issues prevented the reload.  Have changed this to use declarative style which is now used by gradle.
* Spotbugs now reported that the suppression messages were no longer required:
> Suppressing annotations &SuppressFBWarnings should be removed from the source code as soon as they are no more needed. Leaving them may result in accidental warnings suppression. The annotation was probably added to suppress a warning raised by SpotBugs, but now SpotBugs does not report the bug anymore. Either the bug was solved or SpotBugs was updated, and the bug is no longer raised by that code.
* Spotbugs now failed on the deprecated method for `.ensureIndex`.  The recommended drop in replacement is `.createIndex` which now has the same functionality.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
