### PR TITLE
add cooldown of 7 days to gradle package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,16 +4,24 @@ updates:
     directory: "/service"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "gradle"
     directory: "/e2e-tests"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "gradle"
     directory: "/mock-mhs-adaptor"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "gradle"
     directory: "/wiremock"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 


### PR DESCRIPTION
## What

Add default cooldown of 7 days to dependabot.yml for gradle packages.

## Why

Following on from recent compromised package updates, we want to enforce a 7 day cooldown on any package updates to ensure that we're not potentially bringing dangerous updates into our deployments.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
