### PR TITLE
Changed timing of check from before to after message wrapping

### DIFF
--- a/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/StructuredRecordMappingService.java
+++ b/service/src/main/java/uk/nhs/adaptors/gp2gp/gpc/StructuredRecordMappingService.java
@@ -152,16 +152,18 @@ public class StructuredRecordMappingService {
                 .mapBundleToEhrFhirExtractParams(structuredTaskDefinition, bundle);
         String ehrExtractContent = ehrExtractMapper.mapEhrExtractToXml(ehrExtractTemplateParameters);
 
+        ehrExtractStatusService.saveEhrExtractMessageId(structuredTaskDefinition.getConversationId(),
+                ehrExtractTemplateParameters.getEhrExtractId());
+
+        String wrappedMessage = outputMessageWrapperMapper.map(structuredTaskDefinition, ehrExtractContent);
+
         try {
-            ehrExtractMapper.validateXmlAgainstSchema(ehrExtractContent);
+            ehrExtractMapper.validateXmlAgainstSchema(wrappedMessage);
         } catch (XmlSchemaValidationException e) {
             LOGGER.error("EHR Extract XML validation failed: {}", e.getMessage());
         }
 
-        ehrExtractStatusService.saveEhrExtractMessageId(structuredTaskDefinition.getConversationId(),
-                ehrExtractTemplateParameters.getEhrExtractId());
-
-        return outputMessageWrapperMapper.map(structuredTaskDefinition, ehrExtractContent);
+        return wrappedMessage;
     }
 
     @SneakyThrows

--- a/service/src/test/java/uk/nhs/adaptors/gp2gp/gpc/StructuredRecordMappingServiceTest.java
+++ b/service/src/test/java/uk/nhs/adaptors/gp2gp/gpc/StructuredRecordMappingServiceTest.java
@@ -299,13 +299,13 @@ class StructuredRecordMappingServiceTest {
                 .thenReturn(expectedHL7);
 
         doThrow(new XmlSchemaValidationException("Invalid XML", new RuntimeException("Invalid XML")))
-                .when(ehrExtractMapper).validateXmlAgainstSchema(ehrExtractContent);
+                .when(ehrExtractMapper).validateXmlAgainstSchema(expectedHL7);
 
         var actualHL7 = structuredRecordMappingService.mapStructuredRecordToEhrExtractXml(structuredTaskDefinition, bundle);
 
         verify(ehrExtractMapper).mapBundleToEhrFhirExtractParams(structuredTaskDefinition, bundle);
         verify(ehrExtractMapper).mapEhrExtractToXml(ehrExtractTemplateParameters);
-        verify(ehrExtractMapper).validateXmlAgainstSchema(ehrExtractContent);
+        verify(ehrExtractMapper).validateXmlAgainstSchema(expectedHL7);
         verify(outputMessageWrapperMapper).map(structuredTaskDefinition, ehrExtractContent);
         verify(ehrExtractStatusService).saveEhrExtractMessageId(conversationId, ehrExtractId);
 


### PR DESCRIPTION
## What

Ticket reference: [NIAD-3462](https://nhse-dsic.atlassian.net/browse/NIAD-3462?search_id=e70473ee-ff12-49d6-97fc-02fdc8b0f76d)

The XML schema validation to is now running after the message is wrapped, instead of before, so that the full `RCMR_IN030000UK06` or `RCMR_IN030000UK07` message is validated against the correct schema, rather than the bare `<EhrExtract>` fragment which would always fail validation regardless if it’s redaction or not.

## Why

NME raised an incident related to a failed validation.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Internal change (non-breaking change with no effect on the functionality affecting end users)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
