### PR TITLE
NIAD-3463: Temporarily disable Mutation testing

### DIFF
--- a/.github/workflows/mutationtesting.yml
+++ b/.github/workflows/mutationtesting.yml
@@ -1,28 +1,28 @@
-name: Mutation Testing
-on:
-  pull_request:
-
-jobs:
-  pitest:
-    # Only run on PRs from the repo. PRs from forks will fail due to lack of permissions and
-    # must use a two stage process
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout project
-        uses: actions/checkout@v4
-        with:
-          # important to set a fetch depth of 2. By default the checkout action make no history available
-          fetch-depth: 2
-      - name: Setup Java JDK
-        uses: actions/setup-java@v4.2.2
-        with:
-          distribution: 'temurin'
-          java-version: 21
-      - name: run pitest
-        working-directory: ./service
-        run: |
-          echo "api.version=1.44" > $HOME/.docker-java.properties &&
-          ./gradlew pitest-github
-        env:
-          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#name: Mutation Testing
+#on:
+#  pull_request:
+#
+#jobs:
+#  pitest:
+#    # Only run on PRs from the repo. PRs from forks will fail due to lack of permissions and
+#    # must use a two stage process
+#    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Checkout project
+#        uses: actions/checkout@v4
+#        with:
+#          # important to set a fetch depth of 2. By default the checkout action make no history available
+#          fetch-depth: 2
+#      - name: Setup Java JDK
+#        uses: actions/setup-java@v4.2.2
+#        with:
+#          distribution: 'temurin'
+#          java-version: 21
+#      - name: run pitest
+#        working-directory: ./service
+#        run: |
+#          echo "api.version=1.44" > $HOME/.docker-java.properties &&
+#          ./gradlew pitest-github
+#        env:
+#          REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -9,8 +9,8 @@ plugins {
 	id 'org.sonarqube' version '6.3.1.5724'
 
 	// Mutation testing
-	id 'info.solidsoft.pitest' version '1.15.0'
-	id 'com.arcmutate.github' version '2.2.4'
+//	id 'info.solidsoft.pitest' version '1.15.0'
+//	id 'com.arcmutate.github' version '2.2.4'
 }
 
 spotbugs {
@@ -96,8 +96,8 @@ dependencies {
 	spotbugs 'com.github.spotbugs:spotbugs:4.9.8'
 	spotbugs 'com.github.spotbugs:spotbugs-annotations:4.9.8'
 
-	pitest 'com.arcmutate:base:1.3.2'
-	pitest 'com.arcmutate:pitest-git-plugin:2.1.0'
+//	pitest 'com.arcmutate:base:1.3.2'
+//	pitest 'com.arcmutate:pitest-git-plugin:2.1.0'
 }
 
 dependencyManagement {
@@ -179,25 +179,25 @@ spotbugsMain {
 	excludeFilter.set(file("spotbugs/exclude.xml"))
 }
 
-pitest {
-	pitestVersion = '1.16.3'
-	junit5PluginVersion = '1.2.1'
-	outputFormats = ['gitci']
-
-	// git feature limits analysis to contents of PR only
-	features = ["+GIT(from[HEAD~1])"]
-
-	// PRs which don't introduce any production code changes, shouldn't fail the Mutation Testing Actions Workflow
-	failWhenNoMutations = false
-
-	mutators = ['STRONGER', 'EXTENDED_ALL']
-
-	threads = project.getGradle().getStartParameter().getMaxWorkerCount()
-}
-
-pitestGithub {
-	deleteOldSummaries = true
-}
+//pitest {
+//	pitestVersion = '1.16.3'
+//	junit5PluginVersion = '1.2.1'
+//	outputFormats = ['gitci']
+//
+//	// git feature limits analysis to contents of PR only
+//	features = ["+GIT(from[HEAD~1])"]
+//
+//	// PRs which don't introduce any production code changes, shouldn't fail the Mutation Testing Actions Workflow
+//	failWhenNoMutations = false
+//
+//	mutators = ['STRONGER', 'EXTENDED_ALL']
+//
+//	threads = project.getGradle().getStartParameter().getMaxWorkerCount()
+//}
+//
+//pitestGithub {
+//	deleteOldSummaries = true
+//}
 
 sonar {
 	properties {


### PR DESCRIPTION
## What

* Comment out code relating to mutation tests in `build.gradle`s.
* Comment out `mutation-tests.yml` in `.github\workflows`.
 
## Why

In the case we do not get an exemption, we will need to temporarily make our GitHub repositories private whilst the NHS develops a strategy against malicious AI threat actors.

## Type of change

Please delete options that are not relevant.

- [x] Internal change (non-breaking change with no effect on the functionality affecting end users)

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
